### PR TITLE
chore: update latest mapping for mysql

### DIFF
--- a/docs/resources/source_mongodb.md
+++ b/docs/resources/source_mongodb.md
@@ -61,11 +61,11 @@ output "example-source-mongodb" {
 
 - `array_encoding` (String) How to encode arrays. 'Array' encodes them as Array objects but requires all values in the array to be of the same type. 'Array_String' encodes them as JSON Strings and should be used if arrays have mixed types
 - `nested_document_encoding` (String) How to encode nested documents. 'Document' encodes them as JSON Objects, 'String' encodes them as JSON Strings
+- `predicates_istopictoenrich_pattern` (String) Regex pattern to match topics for enrichment
 - `ssh_enabled` (Boolean) Connect via SSH tunnel
 - `ssh_host` (String) Hostname of the SSH server, only required if `ssh_enabled` is true
 - `ssh_port` (String) Port of the SSH server, only required if `ssh_enabled` is true
 - `ssh_user` (String) User for connecting to the SSH server, only required if `ssh_enabled` is true
-- `predicates_istopictoenrich_pattern` (String) Regex pattern to match topics for enrichment
 
 ### Read-Only
 

--- a/docs/resources/source_mysql.md
+++ b/docs/resources/source_mysql.md
@@ -79,17 +79,21 @@ output "example-source-mysql" {
 - `heartbeat_data_collection_schema_or_database` (String) Heartbeat Table Database
 - `heartbeat_enabled` (Boolean) Heartbeats are used to keep the pipeline healthy when there is a low volume of data at times.
 - `heartbeat_interval_min` (Number) Interval in minutes between heartbeats
-- `insert_static_key_field` (String) The name of the static field to be added to the message key.
-- `insert_static_key_value` (String) The value of the static field to be added to the message key.
-- `insert_static_value` (String) The value of the static field to be added to the message value.
-- `insert_static_value_field` (String) The name of the static field to be added to the message value.
+- `insert_static_key_field_1` (String) The name of the static field to be added to the message key.
+- `insert_static_key_field_2` (String) The name of the static field to be added to the message key.
+- `insert_static_key_value_1` (String) The value of the static field to be added to the message key.
+- `insert_static_key_value_2` (String) The value of the static field to be added to the message key.
+- `insert_static_value_1` (String) The value of the static field to be added to the message value.
+- `insert_static_value_2` (String) The value of the static field to be added to the message value.
+- `insert_static_value_field_1` (String) The name of the static field to be added to the message value.
+- `insert_static_value_field_2` (String) The name of the static field to be added to the message value.
+- `predicates_istopictoenrich_pattern` (String) Regex pattern to match topics for enrichment
 - `signal_data_collection_schema_or_database` (String) Schema for signal data collection. If connector is in read-only mode (snapshot_gtid="Yes"), set this to null.
 - `snapshot_gtid` (Boolean) GTID snapshots are read only but require some prerequisite settings, including enabling GTID on the source database. See the documentation for more details.
 - `ssh_enabled` (Boolean) Connect via SSH tunnel
 - `ssh_host` (String) Hostname of the SSH server, only required if `ssh_enabled` is true
 - `ssh_port` (String) Port of the SSH server, only required if `ssh_enabled` is true
 - `ssh_user` (String) User for connecting to the SSH server, only required if `ssh_enabled` is true
-- `predicates_istopictoenrich_pattern` (String) Regex pattern to match topics for enrichment
 
 ### Read-Only
 

--- a/docs/resources/source_postgresql.md
+++ b/docs/resources/source_postgresql.md
@@ -86,6 +86,7 @@ output "example-source-postgresql" {
 - `heartbeat_enabled` (Boolean) Enable heartbeat to keep the pipeline healthy during low data volume
 - `heartbeat_interval_min` (Number) The interval (minutes) at which the heartbeat event is generated
 - `include_source_db_name_in_table_name` (Boolean) Prefix topics with the database name
+- `predicates_istopictoenrich_pattern` (String) Regex pattern to match topics for enrichment
 - `publication_name` (String) Publication name for the connector
 - `signal_data_collection_schema_or_database` (String) Schema for signal data collection
 - `slot_name` (String) Replication slot name for the connector
@@ -94,7 +95,6 @@ output "example-source-postgresql" {
 - `ssh_host` (String) Hostname of the SSH server, only required if `ssh_enabled` is true
 - `ssh_port` (String) Port of the SSH server, only required if `ssh_enabled` is true
 - `ssh_user` (String) User for connecting to the SSH server, only required if `ssh_enabled` is true
-- `predicates_istopictoenrich_pattern` (String) Regex pattern to match topics for enrichment
 
 ### Read-Only
 

--- a/internal/resource/source/mysql.go
+++ b/internal/resource/source/mysql.go
@@ -58,10 +58,14 @@ type SourceMySQLResourceModel struct {
 	SnapshotGTID                            types.Bool   `tfsdk:"snapshot_gtid"`
 	BinaryHandlingMode                      types.String `tfsdk:"binary_handling_mode"`
 	DatabaseConnectionTimezone              types.String `tfsdk:"database_connection_timezone"`
-	InsertStaticKeyField                    types.String `tfsdk:"insert_static_key_field"`
-	InsertStaticKeyValue                    types.String `tfsdk:"insert_static_key_value"`
-	InsertStaticValueField                  types.String `tfsdk:"insert_static_value_field"`
-	InsertStaticValue                       types.String `tfsdk:"insert_static_value"`
+	InsertStaticKeyField1                   types.String `tfsdk:"insert_static_key_field_1"`
+	InsertStaticKeyValue1                   types.String `tfsdk:"insert_static_key_value_1"`
+	InsertStaticValueField1                 types.String `tfsdk:"insert_static_value_field_1"`
+	InsertStaticValue1                      types.String `tfsdk:"insert_static_value_1"`
+	InsertStaticKeyField2                   types.String `tfsdk:"insert_static_key_field_2"`
+	InsertStaticKeyValue2                   types.String `tfsdk:"insert_static_key_value_2"`
+	InsertStaticValueField2                 types.String `tfsdk:"insert_static_value_field_2"`
+	InsertStaticValue2                      types.String `tfsdk:"insert_static_value_2"`
 	SSHEnabled                              types.Bool   `tfsdk:"ssh_enabled"`
 	SSHHost                                 types.String `tfsdk:"ssh_host"`
 	SSHPort                                 types.String `tfsdk:"ssh_port"`
@@ -262,28 +266,56 @@ func (r *SourceMySQLResource) Schema(ctx context.Context, req res.SchemaRequest,
 					),
 				},
 			},
-			"insert_static_key_field": schema.StringAttribute{
+			"insert_static_key_field_1": schema.StringAttribute{
 				Computed:            true,
 				Optional:            true,
 				Default:             stringdefault.StaticString(""),
 				Description:         "The name of the static field to be added to the message key.",
 				MarkdownDescription: "The name of the static field to be added to the message key.",
 			},
-			"insert_static_key_value": schema.StringAttribute{
+			"insert_static_key_value_1": schema.StringAttribute{
 				Computed:            true,
 				Optional:            true,
 				Default:             stringdefault.StaticString(""),
 				Description:         "The value of the static field to be added to the message key.",
 				MarkdownDescription: "The value of the static field to be added to the message key.",
 			},
-			"insert_static_value_field": schema.StringAttribute{
+			"insert_static_value_field_1": schema.StringAttribute{
 				Computed:            true,
 				Optional:            true,
 				Default:             stringdefault.StaticString(""),
 				Description:         "The name of the static field to be added to the message value.",
 				MarkdownDescription: "The name of the static field to be added to the message value.",
 			},
-			"insert_static_value": schema.StringAttribute{
+			"insert_static_value_1": schema.StringAttribute{
+				Computed:            true,
+				Optional:            true,
+				Default:             stringdefault.StaticString(""),
+				Description:         "The value of the static field to be added to the message value.",
+				MarkdownDescription: "The value of the static field to be added to the message value.",
+			},
+			"insert_static_key_field_2": schema.StringAttribute{
+				Computed:            true,
+				Optional:            true,
+				Default:             stringdefault.StaticString(""),
+				Description:         "The name of the static field to be added to the message key.",
+				MarkdownDescription: "The name of the static field to be added to the message key.",
+			},
+			"insert_static_key_value_2": schema.StringAttribute{
+				Computed:            true,
+				Optional:            true,
+				Default:             stringdefault.StaticString(""),
+				Description:         "The value of the static field to be added to the message key.",
+				MarkdownDescription: "The value of the static field to be added to the message key.",
+			},
+			"insert_static_value_field_2": schema.StringAttribute{
+				Computed:            true,
+				Optional:            true,
+				Default:             stringdefault.StaticString(""),
+				Description:         "The name of the static field to be added to the message value.",
+				MarkdownDescription: "The name of the static field to be added to the message value.",
+			},
+			"insert_static_value_2": schema.StringAttribute{
 				Computed:            true,
 				Optional:            true,
 				Default:             stringdefault.StaticString(""),
@@ -542,10 +574,14 @@ func (r *SourceMySQLResource) model2ConfigMap(model SourceMySQLResourceModel) (m
 		"heartbeat.data.collection.schema.or.database": model.HeartbeatDataCollectionSchemaOrDatabase.ValueStringPointer(),
 		"database.connectionTimeZone":                  model.DatabaseConnectionTimezone.ValueString(),
 		"snapshot.gtid":                                snapshotGTIDStr,
-		"transforms.InsertStaticKey.static.field":      model.InsertStaticKeyField.ValueString(),
-		"transforms.InsertStaticKey.static.value":      model.InsertStaticKeyValue.ValueString(),
-		"transforms.InsertStaticValue.static.field":    model.InsertStaticValueField.ValueString(),
-		"transforms.InsertStaticValue.static.value":    model.InsertStaticValue.ValueString(),
+		"transforms.InsertStaticKey1.static.field":      model.InsertStaticKeyField1.ValueString(),
+		"transforms.InsertStaticKey1.static.value":      model.InsertStaticKeyValue1.ValueString(),
+		"transforms.InsertStaticValue1.static.field":    model.InsertStaticValueField1.ValueString(),
+		"transforms.InsertStaticValue1.static.value":    model.InsertStaticValue1.ValueString(),
+		"transforms.InsertStaticKey2.static.field":      model.InsertStaticKeyField2.ValueString(),
+		"transforms.InsertStaticKey2.static.value":      model.InsertStaticKeyValue2.ValueString(),
+		"transforms.InsertStaticValue2.static.field":    model.InsertStaticValueField2.ValueString(),
+		"transforms.InsertStaticValue2.static.value":    model.InsertStaticValue2.ValueString(),
 		"binary.handling.mode":                         model.BinaryHandlingMode.ValueString(),
 		"ssh.enabled":                                  model.SSHEnabled.ValueBool(),
 		"ssh.host":                                     model.SSHHost.ValueStringPointer(),
@@ -581,10 +617,14 @@ func (r *SourceMySQLResource) configMap2Model(cfg map[string]any, model *SourceM
 	model.HeartbeatDataCollectionSchemaOrDatabase = helper.GetTfCfgString(cfg, "heartbeat.data.collection.schema.or.database")
 	model.DatabaseConnectionTimezone = helper.GetTfCfgString(cfg, "database.connectionTimeZone")
 	model.SnapshotGTID = types.BoolValue(helper.GetTfCfgString(cfg, "snapshot.gtid").ValueString() == "Yes")
-	model.InsertStaticKeyField = helper.GetTfCfgString(cfg, "transforms.InsertStaticKey.static.field")
-	model.InsertStaticKeyValue = helper.GetTfCfgString(cfg, "transforms.InsertStaticKey.static.value")
-	model.InsertStaticValueField = helper.GetTfCfgString(cfg, "transforms.InsertStaticValue.static.field")
-	model.InsertStaticValue = helper.GetTfCfgString(cfg, "transforms.InsertStaticValue.static.value")
+	model.InsertStaticKeyField1 = helper.GetTfCfgString(cfg, "transforms.InsertStaticKey1.static.field")
+	model.InsertStaticKeyValue1 = helper.GetTfCfgString(cfg, "transforms.InsertStaticKey1.static.value")
+	model.InsertStaticValueField1 = helper.GetTfCfgString(cfg, "transforms.InsertStaticValue1.static.field")
+	model.InsertStaticValue1 = helper.GetTfCfgString(cfg, "transforms.InsertStaticValue1.static.value")
+	model.InsertStaticKeyField2 = helper.GetTfCfgString(cfg, "transforms.InsertStaticKey2.static.field")
+	model.InsertStaticKeyValue2 = helper.GetTfCfgString(cfg, "transforms.InsertStaticKey2.static.value")
+	model.InsertStaticValueField2 = helper.GetTfCfgString(cfg, "transforms.InsertStaticValue2.static.field")
+	model.InsertStaticValue2 = helper.GetTfCfgString(cfg, "transforms.InsertStaticValue2.static.value")
 	model.BinaryHandlingMode = helper.GetTfCfgString(cfg, "binary.handling.mode")
 	model.SSHEnabled = helper.GetTfCfgBool(cfg, "ssh.enabled")
 	model.SSHHost = helper.GetTfCfgString(cfg, "ssh.host")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated documentation to remove duplicate entries for the `predicates_istopictoenrich_pattern` attribute in MongoDB and PostgreSQL resource docs.
  - Revised MySQL resource documentation to split static field parameters into two numbered variants each and added a new optional parameter for topic enrichment.

- **New Features**
  - MySQL resource now supports two sets of static key/value and value field/value pairs for enhanced configuration flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->