### PR TITLE
chore: remove heartbeat_interval_min

### DIFF
--- a/docs/resources/source_mysql.md
+++ b/docs/resources/source_mysql.md
@@ -78,7 +78,6 @@ output "example-source-mysql" {
 - `database_port` (Number) MySQL Port. For example, 3306
 - `heartbeat_data_collection_schema_or_database` (String) Heartbeat Table Database
 - `heartbeat_enabled` (Boolean) Heartbeats are used to keep the pipeline healthy when there is a low volume of data at times.
-- `heartbeat_interval_min` (Number) Interval in minutes between heartbeats
 - `insert_static_key_field_1` (String) The name of the static field to be added to the message key.
 - `insert_static_key_field_2` (String) The name of the static field to be added to the message key.
 - `insert_static_key_value_1` (String) The value of the static field to be added to the message key.

--- a/docs/resources/source_postgresql.md
+++ b/docs/resources/source_postgresql.md
@@ -84,7 +84,6 @@ output "example-source-postgresql" {
 - `database_sslmode` (String) Whether to use an encrypted connection to the PostgreSQL server
 - `heartbeat_data_collection_schema_or_database` (String) Schema for heartbeat data collection
 - `heartbeat_enabled` (Boolean) Enable heartbeat to keep the pipeline healthy during low data volume
-- `heartbeat_interval_min` (Number) The interval (minutes) at which the heartbeat event is generated
 - `include_source_db_name_in_table_name` (Boolean) Prefix topics with the database name
 - `predicates_istopictoenrich_pattern` (String) Regex pattern to match topics for enrichment
 - `publication_name` (String) Publication name for the connector

--- a/internal/provider/source_mysql_resource_test.go
+++ b/internal/provider/source_mysql_resource_test.go
@@ -59,7 +59,6 @@ resource "streamkap_source_mysql" "test" {
 					resource.TestCheckResourceAttr("streamkap_source_mysql.test", "ssh_enabled", "false"),
 					// Check defaults for unset attributes
 					resource.TestCheckResourceAttr("streamkap_source_mysql.test", "heartbeat_enabled", "false"),
-					resource.TestCheckResourceAttr("streamkap_source_mysql.test", "heartbeat_interval_min", "5"),
 				),
 			},
 			// Step 2: ImportState testing

--- a/internal/provider/source_mysql_resource_test.go
+++ b/internal/provider/source_mysql_resource_test.go
@@ -164,10 +164,6 @@ resource "streamkap_source_mysql" "test" {
 	table_include_list                        = "crm.demo"
 	signal_data_collection_schema_or_database = "crm"
 	column_include_list                       = "crm[.]demo[.](id|name)"
-	insert_static_key_field                   = "static_key"
-	insert_static_key_value                   = "key_value"
-	insert_static_value_field                 = "static_value"
-	insert_static_value                       = "value"
 	heartbeat_enabled                         = true
 	heartbeat_data_collection_schema_or_database = "crm"
 	database_connection_timezone              = "SERVER"
@@ -178,10 +174,6 @@ resource "streamkap_source_mysql" "test" {
 `,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("streamkap_source_mysql.test", "name", "test-source-mysql-static"),
-					resource.TestCheckResourceAttr("streamkap_source_mysql.test", "insert_static_key_field", "static_key"),
-					resource.TestCheckResourceAttr("streamkap_source_mysql.test", "insert_static_key_value", "key_value"),
-					resource.TestCheckResourceAttr("streamkap_source_mysql.test", "insert_static_value_field", "static_value"),
-					resource.TestCheckResourceAttr("streamkap_source_mysql.test", "insert_static_value", "value"),
 					resource.TestCheckResourceAttr("streamkap_source_mysql.test", "column_include_list", "crm[.]demo[.](id|name)"),
 				),
 			},
@@ -211,10 +203,6 @@ resource "streamkap_source_mysql" "test" {
 	table_include_list                        = "crm.demo"
 	signal_data_collection_schema_or_database = "crm"
 	column_include_list                       = "crm[.]demo[.](id|name)"
-	insert_static_key_field                   = "static_key"
-	insert_static_key_value                   = "key_value"
-	insert_static_value_field                 = "static_value"
-	insert_static_value                       = "value"
 	heartbeat_enabled                         = true
 	heartbeat_data_collection_schema_or_database = "crm"
 	database_connection_timezone              = "SERVER"

--- a/internal/provider/source_postgresql_resource_test.go
+++ b/internal/provider/source_postgresql_resource_test.go
@@ -64,7 +64,6 @@ resource "streamkap_source_postgresql" "test" {
 					resource.TestCheckResourceAttr("streamkap_source_postgresql.test", "column_include_list", "streamkap[.]customer[.](id|name)"),
 					// Check defaults for unset attributes
 					resource.TestCheckResourceAttr("streamkap_source_postgresql.test", "heartbeat_enabled", "false"),
-					resource.TestCheckResourceAttr("streamkap_source_postgresql.test", "heartbeat_interval_min", "5"),
 					resource.TestCheckResourceAttr("streamkap_source_postgresql.test", "include_source_db_name_in_table_name", "false"),
 					resource.TestCheckResourceAttr("streamkap_source_postgresql.test", "slot_name", "terraform_pgoutput_slot"),
 					resource.TestCheckResourceAttr("streamkap_source_postgresql.test", "publication_name", "terraform_pub"),
@@ -126,7 +125,6 @@ resource "streamkap_source_postgresql" "test" {
 					resource.TestCheckResourceAttr("streamkap_source_postgresql.test", "signal_data_collection_schema_or_database", "streamkap"),
 					resource.TestCheckResourceAttr("streamkap_source_postgresql.test", "column_include_list", "streamkap[.]customer[.](id|name)"),
 					resource.TestCheckResourceAttr("streamkap_source_postgresql.test", "heartbeat_enabled", "false"),
-					resource.TestCheckResourceAttr("streamkap_source_postgresql.test", "heartbeat_interval_min", "5"),
 					resource.TestCheckResourceAttr("streamkap_source_postgresql.test", "include_source_db_name_in_table_name", "false"),
 					resource.TestCheckResourceAttr("streamkap_source_postgresql.test", "slot_name", "terraform_pgoutput_slot"),
 					resource.TestCheckResourceAttr("streamkap_source_postgresql.test", "publication_name", "terraform_pub"),
@@ -184,7 +182,6 @@ resource "streamkap_source_postgresql" "test" {
 					// Verify column_include_list is not set (null)
 					resource.TestCheckNoResourceAttr("streamkap_source_postgresql.test", "column_include_list"),
 					resource.TestCheckResourceAttr("streamkap_source_postgresql.test", "heartbeat_enabled", "false"),
-					resource.TestCheckResourceAttr("streamkap_source_postgresql.test", "heartbeat_interval_min", "5"),
 					resource.TestCheckResourceAttr("streamkap_source_postgresql.test", "include_source_db_name_in_table_name", "false"),
 					resource.TestCheckResourceAttr("streamkap_source_postgresql.test", "slot_name", "terraform_pgoutput_slot"),
 					resource.TestCheckResourceAttr("streamkap_source_postgresql.test", "publication_name", "terraform_pub"),
@@ -247,7 +244,6 @@ resource "streamkap_source_postgresql" "test" {
 					resource.TestCheckResourceAttr("streamkap_source_postgresql.test", "signal_data_collection_schema_or_database", "streamkap"),
 					resource.TestCheckResourceAttr("streamkap_source_postgresql.test", "column_include_list", "streamkap[.]customer[.](id|name)"),
 					resource.TestCheckResourceAttr("streamkap_source_postgresql.test", "heartbeat_enabled", "false"),
-					resource.TestCheckResourceAttr("streamkap_source_postgresql.test", "heartbeat_interval_min", "5"),
 					resource.TestCheckResourceAttr("streamkap_source_postgresql.test", "include_source_db_name_in_table_name", "false"),
 					resource.TestCheckResourceAttr("streamkap_source_postgresql.test", "slot_name", "terraform_pgoutput_slot"),
 					resource.TestCheckResourceAttr("streamkap_source_postgresql.test", "publication_name", "terraform_pub"),

--- a/internal/resource/source/mongodb.go
+++ b/internal/resource/source/mongodb.go
@@ -53,6 +53,14 @@ type SourceMongoDBResourceModel struct {
 	SSHPort                              types.String `tfsdk:"ssh_port"`
 	SSHUser                              types.String `tfsdk:"ssh_user"`
 	PredicatesIsTopicToEnrichPattern     types.String `tfsdk:"predicates_istopictoenrich_pattern"`
+	InsertStaticKeyField1                   types.String `tfsdk:"insert_static_key_field_1"`
+	InsertStaticKeyValue1                   types.String `tfsdk:"insert_static_key_value_1"`
+	InsertStaticValueField1                 types.String `tfsdk:"insert_static_value_field_1"`
+	InsertStaticValue1                      types.String `tfsdk:"insert_static_value_1"`
+	InsertStaticKeyField2                   types.String `tfsdk:"insert_static_key_field_2"`
+	InsertStaticKeyValue2                   types.String `tfsdk:"insert_static_key_value_2"`
+	InsertStaticValueField2                 types.String `tfsdk:"insert_static_value_field_2"`
+	InsertStaticValue2                      types.String `tfsdk:"insert_static_value_2"`
 }
 
 func (r *SourceMongoDBResource) Metadata(ctx context.Context, req res.MetadataRequest, resp *res.MetadataResponse) {
@@ -162,6 +170,62 @@ func (r *SourceMongoDBResource) Schema(ctx context.Context, req res.SchemaReques
 				Default:             stringdefault.StaticString("$^"),
 				Description:         "Regex pattern to match topics for enrichment",
 				MarkdownDescription: "Regex pattern to match topics for enrichment",
+			},
+			"insert_static_key_field_1": schema.StringAttribute{
+				Computed:            true,
+				Optional:            true,
+				Default:             stringdefault.StaticString(""),
+				Description:         "The name of the static field to be added to the message key.",
+				MarkdownDescription: "The name of the static field to be added to the message key.",
+			},
+			"insert_static_key_value_1": schema.StringAttribute{
+				Computed:            true,
+				Optional:            true,
+				Default:             stringdefault.StaticString(""),
+				Description:         "The value of the static field to be added to the message key.",
+				MarkdownDescription: "The value of the static field to be added to the message key.",
+			},
+			"insert_static_value_field_1": schema.StringAttribute{
+				Computed:            true,
+				Optional:            true,
+				Default:             stringdefault.StaticString(""),
+				Description:         "The name of the static field to be added to the message value.",
+				MarkdownDescription: "The name of the static field to be added to the message value.",
+			},
+			"insert_static_value_1": schema.StringAttribute{
+				Computed:            true,
+				Optional:            true,
+				Default:             stringdefault.StaticString(""),
+				Description:         "The value of the static field to be added to the message value.",
+				MarkdownDescription: "The value of the static field to be added to the message value.",
+			},
+			"insert_static_key_field_2": schema.StringAttribute{
+				Computed:            true,
+				Optional:            true,
+				Default:             stringdefault.StaticString(""),
+				Description:         "The name of the static field to be added to the message key.",
+				MarkdownDescription: "The name of the static field to be added to the message key.",
+			},
+			"insert_static_key_value_2": schema.StringAttribute{
+				Computed:            true,
+				Optional:            true,
+				Default:             stringdefault.StaticString(""),
+				Description:         "The value of the static field to be added to the message key.",
+				MarkdownDescription: "The value of the static field to be added to the message key.",
+			},
+			"insert_static_value_field_2": schema.StringAttribute{
+				Computed:            true,
+				Optional:            true,
+				Default:             stringdefault.StaticString(""),
+				Description:         "The name of the static field to be added to the message value.",
+				MarkdownDescription: "The name of the static field to be added to the message value.",
+			},
+			"insert_static_value_2": schema.StringAttribute{
+				Computed:            true,
+				Optional:            true,
+				Default:             stringdefault.StaticString(""),
+				Description:         "The value of the static field to be added to the message value.",
+				MarkdownDescription: "The value of the static field to be added to the message value.",
 			},
 		},
 	}
@@ -336,6 +400,14 @@ func (r *SourceMongoDBResource) model2ConfigMap(model SourceMongoDBResourceModel
 		"ssh.port":    model.SSHPort.ValueString(),
 		"ssh.user":    model.SSHUser.ValueString(),
 		"predicates.IsTopicToEnrich.pattern":    model.PredicatesIsTopicToEnrichPattern.ValueString(),
+		"transforms.InsertStaticKey1.static.field":      model.InsertStaticKeyField1.ValueString(),
+		"transforms.InsertStaticKey1.static.value":      model.InsertStaticKeyValue1.ValueString(),
+		"transforms.InsertStaticValue1.static.field":    model.InsertStaticValueField1.ValueString(),
+		"transforms.InsertStaticValue1.static.value":    model.InsertStaticValue1.ValueString(),
+		"transforms.InsertStaticKey2.static.field":      model.InsertStaticKeyField2.ValueString(),
+		"transforms.InsertStaticKey2.static.value":      model.InsertStaticKeyValue2.ValueString(),
+		"transforms.InsertStaticValue2.static.field":    model.InsertStaticValueField2.ValueString(),
+		"transforms.InsertStaticValue2.static.value":    model.InsertStaticValue2.ValueString(),
 	}
 }
 
@@ -352,4 +424,12 @@ func (r *SourceMongoDBResource) configMap2Model(cfg map[string]any, model *Sourc
 	model.SSHPort = helper.GetTfCfgString(cfg, "ssh.port")
 	model.SSHUser = helper.GetTfCfgString(cfg, "ssh.user")
 	model.PredicatesIsTopicToEnrichPattern = helper.GetTfCfgString(cfg, "predicates.IsTopicToEnrich.pattern")
+	model.InsertStaticKeyField1 = helper.GetTfCfgString(cfg, "transforms.InsertStaticKey1.static.field")
+	model.InsertStaticKeyValue1 = helper.GetTfCfgString(cfg, "transforms.InsertStaticKey1.static.value")
+	model.InsertStaticValueField1 = helper.GetTfCfgString(cfg, "transforms.InsertStaticValue1.static.field")
+	model.InsertStaticValue1 = helper.GetTfCfgString(cfg, "transforms.InsertStaticValue1.static.value")
+	model.InsertStaticKeyField2 = helper.GetTfCfgString(cfg, "transforms.InsertStaticKey2.static.field")
+	model.InsertStaticKeyValue2 = helper.GetTfCfgString(cfg, "transforms.InsertStaticKey2.static.value")
+	model.InsertStaticValueField2 = helper.GetTfCfgString(cfg, "transforms.InsertStaticValue2.static.field")
+	model.InsertStaticValue2 = helper.GetTfCfgString(cfg, "transforms.InsertStaticValue2.static.value")
 }

--- a/internal/resource/source/mysql.go
+++ b/internal/resource/source/mysql.go
@@ -53,7 +53,6 @@ type SourceMySQLResourceModel struct {
 	ColumnIncludeList                       types.String `tfsdk:"column_include_list"`
 	ColumnExcludeList                       types.String `tfsdk:"column_exclude_list"`
 	HeartbeatEnabled                        types.Bool   `tfsdk:"heartbeat_enabled"`
-	HeartbeatIntervalMin                    types.Int64  `tfsdk:"heartbeat_interval_min"`
 	HeartbeatDataCollectionSchemaOrDatabase types.String `tfsdk:"heartbeat_data_collection_schema_or_database"`
 	SnapshotGTID                            types.Bool   `tfsdk:"snapshot_gtid"`
 	BinaryHandlingMode                      types.String `tfsdk:"binary_handling_mode"`
@@ -155,13 +154,6 @@ func (r *SourceMySQLResource) Schema(ctx context.Context, req res.SchemaRequest,
 				Default:             booldefault.StaticBool(false),
 				Description:         "Heartbeats are used to keep the pipeline healthy when there is a low volume of data at times.",
 				MarkdownDescription: "Heartbeats are used to keep the pipeline healthy when there is a low volume of data at times.",
-			},
-			"heartbeat_interval_min": schema.Int64Attribute{
-				Computed:            true,
-				Optional:            true,
-				Default:             int64default.StaticInt64(5),
-				Description:         "Interval in minutes between heartbeats",
-				MarkdownDescription: "Interval in minutes between heartbeats",
 			},
 			"heartbeat_data_collection_schema_or_database": schema.StringAttribute{
 				Optional:            true,
@@ -570,7 +562,6 @@ func (r *SourceMySQLResource) model2ConfigMap(model SourceMySQLResourceModel) (m
 		"signal.data.collection.schema.or.database":    model.SignalDataCollectionSchemaOrDatabase.ValueStringPointer(),
 		"column.include.list.toggled":                  true,
 		"heartbeat.enabled":                            model.HeartbeatEnabled.ValueBool(),
-		"heartbeat.interval.min.user.defined":                       int(model.HeartbeatIntervalMin.ValueInt64()),
 		"heartbeat.data.collection.schema.or.database": model.HeartbeatDataCollectionSchemaOrDatabase.ValueStringPointer(),
 		"database.connectionTimeZone":                  model.DatabaseConnectionTimezone.ValueString(),
 		"snapshot.gtid":                                snapshotGTIDStr,
@@ -613,7 +604,6 @@ func (r *SourceMySQLResource) configMap2Model(cfg map[string]any, model *SourceM
 	model.ColumnIncludeList = helper.GetTfCfgString(cfg, "column.include.list.user.defined")
 	model.ColumnExcludeList = helper.GetTfCfgString(cfg, "column.exclude.list.user.defined")
 	model.HeartbeatEnabled = helper.GetTfCfgBool(cfg, "heartbeat.enabled")
-	model.HeartbeatIntervalMin = helper.GetTfCfgInt64(cfg, "heartbeat.interval.min.user.defined")
 	model.HeartbeatDataCollectionSchemaOrDatabase = helper.GetTfCfgString(cfg, "heartbeat.data.collection.schema.or.database")
 	model.DatabaseConnectionTimezone = helper.GetTfCfgString(cfg, "database.connectionTimeZone")
 	model.SnapshotGTID = types.BoolValue(helper.GetTfCfgString(cfg, "snapshot.gtid").ValueString() == "Yes")

--- a/internal/resource/source/postgresql.go
+++ b/internal/resource/source/postgresql.go
@@ -66,6 +66,14 @@ type SourcePostgreSQLResourceModel struct {
 	SSHPort                                 types.String `tfsdk:"ssh_port"`
 	SSHUser                                 types.String `tfsdk:"ssh_user"`
 	PredicatesIsTopicToEnrichPattern        types.String `tfsdk:"predicates_istopictoenrich_pattern"`
+	InsertStaticKeyField1                   types.String `tfsdk:"insert_static_key_field_1"`
+	InsertStaticKeyValue1                   types.String `tfsdk:"insert_static_key_value_1"`
+	InsertStaticValueField1                 types.String `tfsdk:"insert_static_value_field_1"`
+	InsertStaticValue1                      types.String `tfsdk:"insert_static_value_1"`
+	InsertStaticKeyField2                   types.String `tfsdk:"insert_static_key_field_2"`
+	InsertStaticKeyValue2                   types.String `tfsdk:"insert_static_key_value_2"`
+	InsertStaticValueField2                 types.String `tfsdk:"insert_static_value_field_2"`
+	InsertStaticValue2                      types.String `tfsdk:"insert_static_value_2"`
 }
 
 func (r *SourcePostgreSQLResource) Metadata(ctx context.Context, req res.MetadataRequest, resp *res.MetadataResponse) {
@@ -265,6 +273,62 @@ func (r *SourcePostgreSQLResource) Schema(ctx context.Context, req res.SchemaReq
 				Default:             stringdefault.StaticString("$^"),
 				Description:         "Regex pattern to match topics for enrichment",
 				MarkdownDescription: "Regex pattern to match topics for enrichment",
+			},
+			"insert_static_key_field_1": schema.StringAttribute{
+				Computed:            true,
+				Optional:            true,
+				Default:             stringdefault.StaticString(""),
+				Description:         "The name of the static field to be added to the message key.",
+				MarkdownDescription: "The name of the static field to be added to the message key.",
+			},
+			"insert_static_key_value_1": schema.StringAttribute{
+				Computed:            true,
+				Optional:            true,
+				Default:             stringdefault.StaticString(""),
+				Description:         "The value of the static field to be added to the message key.",
+				MarkdownDescription: "The value of the static field to be added to the message key.",
+			},
+			"insert_static_value_field_1": schema.StringAttribute{
+				Computed:            true,
+				Optional:            true,
+				Default:             stringdefault.StaticString(""),
+				Description:         "The name of the static field to be added to the message value.",
+				MarkdownDescription: "The name of the static field to be added to the message value.",
+			},
+			"insert_static_value_1": schema.StringAttribute{
+				Computed:            true,
+				Optional:            true,
+				Default:             stringdefault.StaticString(""),
+				Description:         "The value of the static field to be added to the message value.",
+				MarkdownDescription: "The value of the static field to be added to the message value.",
+			},
+			"insert_static_key_field_2": schema.StringAttribute{
+				Computed:            true,
+				Optional:            true,
+				Default:             stringdefault.StaticString(""),
+				Description:         "The name of the static field to be added to the message key.",
+				MarkdownDescription: "The name of the static field to be added to the message key.",
+			},
+			"insert_static_key_value_2": schema.StringAttribute{
+				Computed:            true,
+				Optional:            true,
+				Default:             stringdefault.StaticString(""),
+				Description:         "The value of the static field to be added to the message key.",
+				MarkdownDescription: "The value of the static field to be added to the message key.",
+			},
+			"insert_static_value_field_2": schema.StringAttribute{
+				Computed:            true,
+				Optional:            true,
+				Default:             stringdefault.StaticString(""),
+				Description:         "The name of the static field to be added to the message value.",
+				MarkdownDescription: "The name of the static field to be added to the message value.",
+			},
+			"insert_static_value_2": schema.StringAttribute{
+				Computed:            true,
+				Optional:            true,
+				Default:             stringdefault.StaticString(""),
+				Description:         "The value of the static field to be added to the message value.",
+				MarkdownDescription: "The value of the static field to be added to the message value.",
 			},
 		},
 	}
@@ -468,6 +532,14 @@ func (r *SourcePostgreSQLResource) model2ConfigMap(model SourcePostgreSQLResourc
 		"ssh.port":                                          model.SSHPort.ValueString(),
 		"ssh.user":                                          model.SSHUser.ValueString(),
 		"predicates.IsTopicToEnrich.pattern":    model.PredicatesIsTopicToEnrichPattern.ValueString(),
+		"transforms.InsertStaticKey1.static.field":      model.InsertStaticKeyField1.ValueString(),
+		"transforms.InsertStaticKey1.static.value":      model.InsertStaticKeyValue1.ValueString(),
+		"transforms.InsertStaticValue1.static.field":    model.InsertStaticValueField1.ValueString(),
+		"transforms.InsertStaticValue1.static.value":    model.InsertStaticValue1.ValueString(),
+		"transforms.InsertStaticKey2.static.field":      model.InsertStaticKeyField2.ValueString(),
+		"transforms.InsertStaticKey2.static.value":      model.InsertStaticKeyValue2.ValueString(),
+		"transforms.InsertStaticValue2.static.field":    model.InsertStaticValueField2.ValueString(),
+		"transforms.InsertStaticValue2.static.value":    model.InsertStaticValue2.ValueString(),
 	}
 
 	if !model.ColumnIncludeList.IsNull() {
@@ -506,4 +578,12 @@ func (r *SourcePostgreSQLResource) configMap2Model(cfg map[string]any, model *So
 	model.SSHPort = helper.GetTfCfgString(cfg, "ssh.port")
 	model.SSHUser = helper.GetTfCfgString(cfg, "ssh.user")
 	model.PredicatesIsTopicToEnrichPattern = helper.GetTfCfgString(cfg, "predicates.IsTopicToEnrich.pattern")
+	model.InsertStaticKeyField1 = helper.GetTfCfgString(cfg, "transforms.InsertStaticKey1.static.field")
+	model.InsertStaticKeyValue1 = helper.GetTfCfgString(cfg, "transforms.InsertStaticKey1.static.value")
+	model.InsertStaticValueField1 = helper.GetTfCfgString(cfg, "transforms.InsertStaticValue1.static.field")
+	model.InsertStaticValue1 = helper.GetTfCfgString(cfg, "transforms.InsertStaticValue1.static.value")
+	model.InsertStaticKeyField2 = helper.GetTfCfgString(cfg, "transforms.InsertStaticKey2.static.field")
+	model.InsertStaticKeyValue2 = helper.GetTfCfgString(cfg, "transforms.InsertStaticKey2.static.value")
+	model.InsertStaticValueField2 = helper.GetTfCfgString(cfg, "transforms.InsertStaticValue2.static.field")
+	model.InsertStaticValue2 = helper.GetTfCfgString(cfg, "transforms.InsertStaticValue2.static.value")
 }

--- a/internal/resource/source/postgresql.go
+++ b/internal/resource/source/postgresql.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	res "github.com/hashicorp/terraform-plugin-framework/resource"
@@ -57,7 +56,6 @@ type SourcePostgreSQLResourceModel struct {
 	ColumnIncludeList                       types.String `tfsdk:"column_include_list"`
 	ColumnExcludeList                       types.String `tfsdk:"column_exclude_list"`
 	HeartbeatEnabled                        types.Bool   `tfsdk:"heartbeat_enabled"`
-	HeartbeatIntervalMin                    types.Int64  `tfsdk:"heartbeat_interval_min"`
 	HeartbeatDataCollectionSchemaOrDatabase types.String `tfsdk:"heartbeat_data_collection_schema_or_database"`
 	IncludeSourceDBNameInTableName          types.Bool   `tfsdk:"include_source_db_name_in_table_name"`
 	SlotName                                types.String `tfsdk:"slot_name"`
@@ -193,16 +191,6 @@ func (r *SourcePostgreSQLResource) Schema(ctx context.Context, req res.SchemaReq
 				Default:             booldefault.StaticBool(false),
 				Description:         "Enable heartbeat to keep the pipeline healthy during low data volume",
 				MarkdownDescription: "Enable heartbeat to keep the pipeline healthy during low data volume",
-			},
-			"heartbeat_interval_min": schema.Int64Attribute{
-				Optional:            true,
-				Computed:            true,
-				Default:             int64default.StaticInt64(5),
-				Description:         "The interval (minutes) at which the heartbeat event is generated",
-				MarkdownDescription: "The interval (minutes) at which the heartbeat event is generated",
-				Validators: []validator.Int64{
-					int64validator.Between(1, 30),
-				},
 			},
 			"heartbeat_data_collection_schema_or_database": schema.StringAttribute{
 				Optional:            true,
@@ -471,7 +459,6 @@ func (r *SourcePostgreSQLResource) model2ConfigMap(model SourcePostgreSQLResourc
 		"column.include.list.toggled":                       true,
 		"heartbeat.enabled":                                 model.HeartbeatEnabled.ValueBool(),
 		"heartbeat.data.collection.schema.or.database":      model.HeartbeatDataCollectionSchemaOrDatabase.ValueStringPointer(),
-		"heartbeat.interval.min.user.defined":               int(model.HeartbeatIntervalMin.ValueInt64()),
 		"include.source.db.name.in.table.name.user.defined": model.IncludeSourceDBNameInTableName.ValueBool(),
 		"slot.name":                                         model.SlotName.ValueString(),
 		"publication.name":                                  model.PublicationName.ValueString(),
@@ -509,7 +496,6 @@ func (r *SourcePostgreSQLResource) configMap2Model(cfg map[string]any, model *So
 	model.ColumnIncludeList = helper.GetTfCfgString(cfg, "column.include.list.user.defined")
 	model.ColumnExcludeList = helper.GetTfCfgString(cfg, "column.exclude.list.user.defined")
 	model.HeartbeatEnabled = helper.GetTfCfgBool(cfg, "heartbeat.enabled")
-	model.HeartbeatIntervalMin = helper.GetTfCfgInt64(cfg, "heartbeat.interval.min.user.defined")
 	model.HeartbeatDataCollectionSchemaOrDatabase = helper.GetTfCfgString(cfg, "heartbeat.data.collection.schema.or.database")
 	model.IncludeSourceDBNameInTableName = helper.GetTfCfgBool(cfg, "include.source.db.name.in.table.name.user.defined")
 	model.SlotName = helper.GetTfCfgString(cfg, "slot.name")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated documentation to remove references to the `heartbeat_interval_min` attribute for MySQL and PostgreSQL source resources.

- **Bug Fixes**
  - Removed the `heartbeat_interval_min` configuration option from MySQL and PostgreSQL source resources, simplifying resource configuration.

- **New Features**
  - Added support for inserting two sets of static key-value pairs into message keys and values for PostgreSQL and MongoDB source resources.

- **Tests**
  - Updated tests to remove checks and assertions related to the `heartbeat_interval_min` attribute for both MySQL and PostgreSQL resources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->