### PR TITLE
chore: update sqlserver config to add databricks catalog

### DIFF
--- a/docs/resources/destination_databricks.md
+++ b/docs/resources/destination_databricks.md
@@ -37,15 +37,16 @@ variable "destination_databricks_token" {
 }
 
 resource "streamkap_destination_databricks" "example-destination-databricks" {
-  name              = "example-destination-databricks"
-  table_name_prefix = "streamkap"
-  ingestion_mode    = "append"
-  partition_mode    = "by_topic"
-  hard_delete       = true
-  tasks_max         = 5
-  connection_url    = var.destination_databricks_connection_url
-  databricks_token  = var.destination_databricks_token
-  schema_evolution  = "basic"
+  name               = "example-destination-databricks"
+  table_name_prefix  = "streamkap"
+  ingestion_mode     = "append"
+  partition_mode     = "by_topic"
+  hard_delete        = true
+  tasks_max          = 5
+  connection_url     = var.destination_databricks_connection_url
+  databricks_token   = var.destination_databricks_token
+  databricks_catalog = "hive_metastore"
+  schema_evolution   = "basic"
 }
 
 output "example-destination-databricks" {
@@ -65,6 +66,7 @@ output "example-destination-databricks" {
 
 ### Optional
 
+- `databricks_catalog` (String) Catalog Name. Make sure to change this to the correct cataog name
 - `hard_delete` (Boolean) Specifies whether the connector processes DELETE or tombstone events and removes the corresponding row from the database (applies to `upsert` only)
 - `ingestion_mode` (String) `upsert` or `append` modes are available
 - `partition_mode` (String) Partition tables or not

--- a/examples/resources/streamkap_destination_databricks/resource.tf
+++ b/examples/resources/streamkap_destination_databricks/resource.tf
@@ -22,15 +22,16 @@ variable "destination_databricks_token" {
 }
 
 resource "streamkap_destination_databricks" "example-destination-databricks" {
-  name              = "example-destination-databricks"
-  table_name_prefix = "streamkap"
-  ingestion_mode    = "append"
-  partition_mode    = "by_topic"
-  hard_delete       = true
-  tasks_max         = 5
-  connection_url    = var.destination_databricks_connection_url
-  databricks_token  = var.destination_databricks_token
-  schema_evolution  = "basic"
+  name               = "example-destination-databricks"
+  table_name_prefix  = "streamkap"
+  ingestion_mode     = "append"
+  partition_mode     = "by_topic"
+  hard_delete        = true
+  tasks_max          = 5
+  connection_url     = var.destination_databricks_connection_url
+  databricks_token   = var.destination_databricks_token
+  databricks_catalog = "hive_metastore"
+  schema_evolution   = "basic"
 }
 
 output "example-destination-databricks" {

--- a/internal/resource/destination/databricks.go
+++ b/internal/resource/destination/databricks.go
@@ -46,6 +46,7 @@ type DestinationDatabricksResourceModel struct {
 	Connector                     types.String            `tfsdk:"connector"`
 	ConnectionUrl                 types.String            `tfsdk:"connection_url"`
 	DatabricksToken               types.String            `tfsdk:"databricks_token"`
+	DatabricksCatalog             types.String            `tfsdk:"databricks_catalog"`
 	TableNamePrefix               types.String            `tfsdk:"table_name_prefix"`
 	IngestionMode                 types.String            `tfsdk:"ingestion_mode"`
 	PartitionMode                 types.String            `tfsdk:"partition_mode"`
@@ -92,6 +93,13 @@ func (r *DestinationDatabricksResource) Schema(ctx context.Context, req res.Sche
 				Sensitive:           true,
 				Description:         "Token",
 				MarkdownDescription: "Token",
+			},
+			"databricks_catalog": schema.StringAttribute{
+				Computed:            true,
+				Optional:            true,
+				Default:             stringdefault.StaticString("hive_metastore"),
+				Description:         "Catalog Name. Make sure to change this to the correct cataog name",
+				MarkdownDescription: "Catalog Name. Make sure to change this to the correct cataog name",
 			},
 			"table_name_prefix": schema.StringAttribute{
 				Required:            true,
@@ -327,6 +335,7 @@ func (r *DestinationDatabricksResource) model2ConfigMap(_ context.Context, model
 	configMap := map[string]any{
 		"connection.url.user.defined": model.ConnectionUrl.ValueString(),
 		"databricks.token":            model.DatabricksToken.ValueString(),
+		"databricks.catalog.user.defined":              model.DatabricksCatalog.ValueString(),
 		"table.name.prefix":           model.TableNamePrefix.ValueString(),
 		"ingestion.mode":              model.IngestionMode.ValueString(),
 		"partition.mode":              model.PartitionMode.ValueString(),
@@ -342,6 +351,7 @@ func (r *DestinationDatabricksResource) configMap2Model(ctx context.Context, cfg
 	// Copy the config map to the model
 	model.ConnectionUrl = helper.GetTfCfgString(cfg, "connection.url.user.defined")
 	model.DatabricksToken = helper.GetTfCfgString(cfg, "databricks.token")
+	model.DatabricksCatalog = helper.GetTfCfgString(cfg, "databricks.catalog.user.defined")
 	model.TableNamePrefix = helper.GetTfCfgString(cfg, "table.name.prefix")
 	model.IngestionMode = helper.GetTfCfgString(cfg, "ingestion.mode")
 	model.PartitionMode = helper.GetTfCfgString(cfg, "partition.mode")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for an optional Databricks catalog attribute in the Databricks destination configuration, allowing users to specify a catalog name (defaulting to "hive_metastore").

* **Documentation**
  * Updated documentation and example resource configuration to describe and demonstrate the new optional Databricks catalog attribute.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->