### PR TITLE
feat: add tasks.max to dynamodb

### DIFF
--- a/docs/resources/source_dynamodb.md
+++ b/docs/resources/source_dynamodb.md
@@ -56,6 +56,7 @@ resource "streamkap_source_dynamodb" "example-source-dynamodb" {
   signal_kafka_poll_timeout_ms     = 1000
   array_encoding_json              = true
   struct_encoding_json             = true
+  tasks_max                        = 3
 }
 
 output "example-source-dynamodb" {
@@ -86,6 +87,7 @@ output "example-source-dynamodb" {
 - `poll_timeout_ms` (Number) Poll Timeout (ms)
 - `signal_kafka_poll_timeout_ms` (Number) Signal Kafka Poll Timeout (ms)
 - `struct_encoding_json` (Boolean) Force nested maps as JSON string
+- `tasks_max` (Number) The maximum number of active task
 
 ### Read-Only
 

--- a/examples/resources/streamkap_source_dynamodb/resource.tf
+++ b/examples/resources/streamkap_source_dynamodb/resource.tf
@@ -41,6 +41,7 @@ resource "streamkap_source_dynamodb" "example-source-dynamodb" {
   signal_kafka_poll_timeout_ms     = 1000
   array_encoding_json              = true
   struct_encoding_json             = true
+  tasks_max                        = 3
 }
 
 output "example-source-dynamodb" {

--- a/internal/provider/source_dynamodb_resource_test.go
+++ b/internal/provider/source_dynamodb_resource_test.go
@@ -49,6 +49,7 @@ resource "streamkap_source_dynamodb" "test" {
 	signal_kafka_poll_timeout_ms     = 1000
 	array_encoding_json              = true
 	struct_encoding_json             = true
+	tasks_max                        = 3
 }
 `,
 
@@ -68,6 +69,7 @@ resource "streamkap_source_dynamodb" "test" {
 					resource.TestCheckResourceAttr("streamkap_source_dynamodb.test", "signal_kafka_poll_timeout_ms", "1000"),
 					resource.TestCheckResourceAttr("streamkap_source_dynamodb.test", "array_encoding_json", "true"),
 					resource.TestCheckResourceAttr("streamkap_source_dynamodb.test", "struct_encoding_json", "true"),
+					resource.TestCheckResourceAttr("streamkap_source_dynamodb.test", "tasks_max", "3"),
 				),
 			},
 			// ImportState testing
@@ -110,6 +112,7 @@ resource "streamkap_source_dynamodb" "test" {
 	signal_kafka_poll_timeout_ms     = 2000
 	array_encoding_json              = true
 	struct_encoding_json             = true
+	tasks_max                        = 5
 }
 `,
 
@@ -129,6 +132,7 @@ resource "streamkap_source_dynamodb" "test" {
 					resource.TestCheckResourceAttr("streamkap_source_dynamodb.test", "signal_kafka_poll_timeout_ms", "2000"),
 					resource.TestCheckResourceAttr("streamkap_source_dynamodb.test", "array_encoding_json", "true"),
 					resource.TestCheckResourceAttr("streamkap_source_dynamodb.test", "struct_encoding_json", "true"),
+					resource.TestCheckResourceAttr("streamkap_source_dynamodb.test", "tasks_max", "5"),
 				),
 			},
 			// Delete testing automatically occurs in TestCase


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new optional attribute, `tasks_max`, to the DynamoDB source resource, allowing users to set the maximum number of active tasks (between 1 and 40, default 10).

* **Documentation**
  * Updated documentation and examples to include the new `tasks_max` attribute with usage details.

* **Tests**
  * Enhanced tests to verify correct handling of the `tasks_max` attribute during creation and updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->