### PR TITLE
chore: set Databricks max tasks limit to 25

### DIFF
--- a/internal/resource/destination/databricks.go
+++ b/internal/resource/destination/databricks.go
@@ -159,7 +159,7 @@ func (r *DestinationDatabricksResource) Schema(ctx context.Context, req res.Sche
 				Description:         "The maximum number of active task",
 				MarkdownDescription: "The maximum number of active task",
 				Validators: []validator.Int64{
-					int64validator.Between(1, 10),
+					int64validator.Between(1, 25),
 				},
 			},
 		},


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Increased the maximum allowed value for the "tasks_max" setting in the Databricks destination from 10 to 25, allowing for greater flexibility in configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->