### PR TITLE
[TERRAFORM, OLD] ENG-7: Allow full path specification for signal table schema

### DIFF
--- a/docs/resources/source_mongodb.md
+++ b/docs/resources/source_mongodb.md
@@ -55,7 +55,7 @@ output "example-source-mongodb" {
 - `database_include_list` (String) Source databases to sync.
 - `mongodb_connection_string` (String, Sensitive) Mongodb Connection String. See Mongodb documentation for further details.
 - `name` (String) Source name
-- `signal_data_collection_schema_or_database` (String) Streamkap will use a collection in this database to monitor incremental snapshotting. Follow the instructions in the documentation for creating this collection and specify which database to use here.
+- `signal_data_collection_schema_or_database` (String) Signal collection location in `database.collection` format (e.g., `admin.streamkap_signal`). For backwards compatibility, you can specify just the database name. Follow the instructions in the documentation for creating this collection.
 
 ### Optional
 

--- a/docs/resources/source_mysql.md
+++ b/docs/resources/source_mysql.md
@@ -44,7 +44,7 @@ resource "streamkap_source_mysql" "test" {
   database_password                         = var.source_mysql_password
   database_include_list                     = "crm,ecommerce,tst"
   table_include_list                        = "crm.demo,ecommerce.customers,tst.test_id_timestamp"
-  signal_data_collection_schema_or_database = "crm"
+  signal_data_collection_schema_or_database = "crm.streamkap_signal"
   column_include_list                       = "crm[.]demo[.](id|name),ecommerce[.]customers[.](customer_id|email)"
   database_connection_timezone              = "SERVER"
   snapshot_gtid                             = true
@@ -87,7 +87,7 @@ output "example-source-mysql" {
 - `insert_static_value_field_1` (String) The name of the static field to be added to the message value.
 - `insert_static_value_field_2` (String) The name of the static field to be added to the message value.
 - `predicates_istopictoenrich_pattern` (String) Regex pattern to match topics for enrichment
-- `signal_data_collection_schema_or_database` (String) Schema for signal data collection. If connector is in read-only mode (snapshot_gtid="Yes"), set this to null.
+- `signal_data_collection_schema_or_database` (String) Signal table location in `database.table` format (e.g., `mydb.streamkap_signal`). For backwards compatibility, you can specify just the database name. If connector is in read-only mode (`snapshot_gtid="Yes"`), set this to null.
 - `snapshot_gtid` (Boolean) GTID snapshots are read only but require some prerequisite settings, including enabling GTID on the source database. See the documentation for more details.
 - `ssh_enabled` (Boolean) Connect via SSH tunnel
 - `ssh_host` (String) Hostname of the SSH server, only required if `ssh_enabled` is true

--- a/docs/resources/source_postgresql.md
+++ b/docs/resources/source_postgresql.md
@@ -46,7 +46,7 @@ resource "streamkap_source_postgresql" "example-source-postgresql" {
   database_sslmode                             = "require"
   schema_include_list                          = "streamkap"
   table_include_list                           = "streamkap.customer,streamkap.customer2"
-  signal_data_collection_schema_or_database    = "streamkap"
+  signal_data_collection_schema_or_database    = "streamkap.streamkap_signal"
   column_include_list                          = "streamkap[.]customer[.](id|name)"
   heartbeat_enabled                            = false
   heartbeat_data_collection_schema_or_database = null
@@ -95,7 +95,7 @@ output "example-source-postgresql" {
 - `insert_static_value_field_2` (String) The name of the static field to be added to the message value.
 - `predicates_istopictoenrich_pattern` (String) Regex pattern to match topics for enrichment
 - `publication_name` (String) Publication name for the connector
-- `signal_data_collection_schema_or_database` (String) Schema for signal data collection
+- `signal_data_collection_schema_or_database` (String) Signal table location in `schema.table` format (e.g., `public.streamkap_signal`). For backwards compatibility, you can specify just the schema name.
 - `slot_name` (String) Replication slot name for the connector
 - `snapshot_read_only` (String) When connecting to a read replica PostgreSQL database, this must be set to 'Yes' to support Streamkap snapshots
 - `ssh_enabled` (Boolean) Connect via SSH tunnel

--- a/docs/resources/source_sqlserver.md
+++ b/docs/resources/source_sqlserver.md
@@ -44,7 +44,7 @@ resource "streamkap_source_sqlserver" "example-source-sqlserver" {
   database_dbname                              = "sqlserverdemo"
   schema_include_list                          = "dbo"
   table_include_list                           = "dbo.Orders"
-  signal_data_collection_schema_or_database    = "streamkap"
+  signal_data_collection_schema_or_database    = "dbo.streamkap_signal"
   heartbeat_enabled                            = false
   heartbeat_data_collection_schema_or_database = null
   binary_handling_mode                         = "bytes"
@@ -92,7 +92,7 @@ output "example-source-sqlserver" {
 - `insert_static_key_value` (String) The value of the static field to be added to the message key.
 - `insert_static_value` (String) The value of the static field to be added to the message value.
 - `insert_static_value_field` (String) The name of the static field to be added to the message value.
-- `signal_data_collection_schema_or_database` (String) Schema for signal data collection. If connector is in read-only mode (snapshot_gtid="Yes"), set this to null.
+- `signal_data_collection_schema_or_database` (String) Signal table location in `schema.table` format (e.g., `dbo.streamkap_signal`). For backwards compatibility, you can specify just the schema name.
 - `snapshot_custom_table_config` (Attributes Map) Explicitly set nb of parallel chunks for tables. Format: {"db.Some_Tbl": {"chunks": 5}}. This allows manual settings for parallelization when stats are outdated and estimated table size cannot be computed reliably (see [below for nested schema](#nestedatt--snapshot_custom_table_config))
 - `snapshot_large_table_threshold` (Number) The threshold in MB for a Large Table to require multiple chunks to be read in parallel
 - `snapshot_parallelism` (Number) How many parallel chunk requests to send to the source DB

--- a/examples/resources/streamkap_source_mysql/resource.tf
+++ b/examples/resources/streamkap_source_mysql/resource.tf
@@ -29,7 +29,7 @@ resource "streamkap_source_mysql" "test" {
   database_password                         = var.source_mysql_password
   database_include_list                     = "crm,ecommerce,tst"
   table_include_list                        = "crm.demo,ecommerce.customers,tst.test_id_timestamp"
-  signal_data_collection_schema_or_database = "crm"
+  signal_data_collection_schema_or_database = "crm.streamkap_signal"
   column_include_list                       = "crm[.]demo[.](id|name),ecommerce[.]customers[.](customer_id|email)"
   database_connection_timezone              = "SERVER"
   snapshot_gtid                             = true

--- a/examples/resources/streamkap_source_postgresql/resource.tf
+++ b/examples/resources/streamkap_source_postgresql/resource.tf
@@ -31,7 +31,7 @@ resource "streamkap_source_postgresql" "example-source-postgresql" {
   database_sslmode                             = "require"
   schema_include_list                          = "streamkap"
   table_include_list                           = "streamkap.customer,streamkap.customer2"
-  signal_data_collection_schema_or_database    = "streamkap"
+  signal_data_collection_schema_or_database    = "streamkap.streamkap_signal"
   column_include_list                          = "streamkap[.]customer[.](id|name)"
   heartbeat_enabled                            = false
   heartbeat_data_collection_schema_or_database = null

--- a/examples/resources/streamkap_source_sqlserver/resource.tf
+++ b/examples/resources/streamkap_source_sqlserver/resource.tf
@@ -29,7 +29,7 @@ resource "streamkap_source_sqlserver" "example-source-sqlserver" {
   database_dbname                              = "sqlserverdemo"
   schema_include_list                          = "dbo"
   table_include_list                           = "dbo.Orders"
-  signal_data_collection_schema_or_database    = "streamkap"
+  signal_data_collection_schema_or_database    = "dbo.streamkap_signal"
   heartbeat_enabled                            = false
   heartbeat_data_collection_schema_or_database = null
   binary_handling_mode                         = "bytes"

--- a/internal/resource/source/mongodb.go
+++ b/internal/resource/source/mongodb.go
@@ -135,8 +135,8 @@ func (r *SourceMongoDBResource) Schema(ctx context.Context, req res.SchemaReques
 			},
 			"signal_data_collection_schema_or_database": schema.StringAttribute{
 				Required:            true,
-				Description:         "Streamkap will use a collection in this database to monitor incremental snapshotting. Follow the instructions in the documentation for creating this collection and specify which database to use here.",
-				MarkdownDescription: "Streamkap will use a collection in this database to monitor incremental snapshotting. Follow the instructions in the documentation for creating this collection and specify which database to use here.",
+				Description:         "Signal collection location in database.collection format (e.g., 'admin.streamkap_signal'). For backwards compatibility, you can specify just the database name. Follow the instructions in the documentation for creating this collection.",
+				MarkdownDescription: "Signal collection location in `database.collection` format (e.g., `admin.streamkap_signal`). For backwards compatibility, you can specify just the database name. Follow the instructions in the documentation for creating this collection.",
 			},
 			"ssh_enabled": schema.BoolAttribute{
 				Computed:            true,

--- a/internal/resource/source/mysql.go
+++ b/internal/resource/source/mysql.go
@@ -135,8 +135,8 @@ func (r *SourceMySQLResource) Schema(ctx context.Context, req res.SchemaRequest,
 			},
 			"signal_data_collection_schema_or_database": schema.StringAttribute{
 				Optional:            true,
-				Description:         "Schema for signal data collection. If connector is in read-only mode (snapshot_gtid=\"Yes\"), set this to null.",
-				MarkdownDescription: "Schema for signal data collection. If connector is in read-only mode (snapshot_gtid=\"Yes\"), set this to null.",
+				Description:         "Signal table location in database.table format (e.g., 'mydb.streamkap_signal'). For backwards compatibility, you can specify just the database name. If connector is in read-only mode (snapshot_gtid=\"Yes\"), set this to null.",
+				MarkdownDescription: "Signal table location in `database.table` format (e.g., `mydb.streamkap_signal`). For backwards compatibility, you can specify just the database name. If connector is in read-only mode (`snapshot_gtid=\"Yes\"`), set this to null.",
 			},
 			"column_include_list": schema.StringAttribute{
 				Optional:            true,

--- a/internal/resource/source/postgresql.go
+++ b/internal/resource/source/postgresql.go
@@ -168,8 +168,8 @@ func (r *SourcePostgreSQLResource) Schema(ctx context.Context, req res.SchemaReq
 				Computed:            true,
 				Optional:            true,
 				Default:             stringdefault.StaticString("public"),
-				Description:         "Schema for signal data collection",
-				MarkdownDescription: "Schema for signal data collection",
+				Description:         "Signal table location in schema.table format (e.g., 'public.streamkap_signal'). For backwards compatibility, you can specify just the schema name.",
+				MarkdownDescription: "Signal table location in `schema.table` format (e.g., `public.streamkap_signal`). For backwards compatibility, you can specify just the schema name.",
 			},
 			"column_include_list": schema.StringAttribute{
 				Optional: true,

--- a/internal/resource/source/sqlserver.go
+++ b/internal/resource/source/sqlserver.go
@@ -142,8 +142,8 @@ func (r *SourceSQLServerResource) Schema(ctx context.Context, req res.SchemaRequ
 			},
 			"signal_data_collection_schema_or_database": schema.StringAttribute{
 				Optional:            true,
-				Description:         "Schema for signal data collection. If connector is in read-only mode (snapshot_gtid=\"Yes\"), set this to null.",
-				MarkdownDescription: "Schema for signal data collection. If connector is in read-only mode (snapshot_gtid=\"Yes\"), set this to null.",
+				Description:         "Signal table location in schema.table format (e.g., 'dbo.streamkap_signal'). For backwards compatibility, you can specify just the schema name.",
+				MarkdownDescription: "Signal table location in `schema.table` format (e.g., `dbo.streamkap_signal`). For backwards compatibility, you can specify just the schema name.",
 			},
 			"column_exclude_list": schema.StringAttribute{
 				Optional:            true,


### PR DESCRIPTION
  Summary

  Updates the Terraform provider documentation to reflect the new signal table full path format (schema.table or database.table) supported by the backend.

**DEPENDS ON**: https://github.com/streamkap-com/backend/pull/1969

  Changes

  Schema Descriptions (4 files)
  - postgresql.go - Updated to describe schema.table format (e.g., public.streamkap_signal)
  - mysql.go - Updated to describe database.table format (e.g., mydb.streamkap_signal)
  - sqlserver.go - Updated to describe schema.table format (e.g., dbo.streamkap_signal)
  - mongodb.go - Updated to describe database.collection format (e.g., admin.streamkap_signal)

  Examples (3 files)
  - PostgreSQL example: "streamkap" → "streamkap.streamkap_signal"
  - MySQL example: "crm" → "crm.streamkap_signal"
  - SQLServer example: "streamkap" → "dbo.streamkap_signal"

  Generated Documentation (4 files)
  - Regenerated via go generate ./... to update markdown docs

  Notes

  - Backwards compatible: Users can still specify just the schema/database name
  - No code logic changes - documentation only
  - Complements backend changes in ENG-7

  Test Plan

  - Verify provider builds successfully
  - Verify existing Terraform configurations continue to work
  - Verify new full path format works with updated backend

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Clarified signal data collection field format across MongoDB, MySQL, PostgreSQL, and SQL Server sources. Updated descriptions and examples to show proper location format (e.g., `database.collection`, `database.table`, `schema.table`) and noted backwards compatibility for specifying just the database/schema name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->