### PR TITLE
STR-4371-kc-api-and-terraform-timeouts

### DIFF
--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -34,6 +34,10 @@ type StreamkapAPI interface {
 
 	// Transform APIs
 	GetTransform(ctx context.Context, transformID string) (*Transform, error)
+	CreateTransform(ctx context.Context, reqPayload Transform) (*Transform, error)
+	UpdateTransform(ctx context.Context, transformID string, reqPayload Transform) (*Transform, error)
+	DeleteTransform(ctx context.Context, transformID string) error
+	DeployTransformLive(ctx context.Context, transformID string, versionID string) error
 
 	// Tags APIs
 	GetTag(ctx context.Context, TagID string) (*Tag, error)

--- a/internal/api/destination.go
+++ b/internal/api/destination.go
@@ -19,10 +19,11 @@ type GetDestinationResponse struct {
 }
 
 type Destination struct {
-	ID        string         `json:"id"`
-	Name      string         `json:"name"`
-	Connector string         `json:"connector"`
-	Config    map[string]any `json:"config"`
+	ID          string         `json:"id"`
+	Name        string         `json:"name"`
+	Connector   string         `json:"connector"`
+	Config      map[string]any `json:"config"`
+	KcClusterId *string        `json:"kc_cluster_id,omitempty"`
 }
 
 func (s *streamkapAPI) CreateDestination(ctx context.Context, reqPayload Destination) (*Destination, error) {

--- a/internal/api/destination.go
+++ b/internal/api/destination.go
@@ -44,7 +44,7 @@ func (s *streamkapAPI) CreateDestination(ctx context.Context, reqPayload Destina
 		return nil, err
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, s.cfg.BaseURL+"/destinations?secret_returned=true", bytes.NewBuffer(payload))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, s.cfg.BaseURL+"/destinations?secret_returned=true&wait=false", bytes.NewBuffer(payload))
 	if err != nil {
 		return nil, err
 	}
@@ -92,7 +92,7 @@ func (s *streamkapAPI) GetDestination(ctx context.Context, destinationID string)
 }
 
 func (s *streamkapAPI) DeleteDestination(ctx context.Context, destinationID string) error {
-	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, s.cfg.BaseURL+"/destinations/"+destinationID+"?secret_returned=true", http.NoBody)
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, s.cfg.BaseURL+"/destinations/"+destinationID+"?secret_returned=true&wait=false", http.NoBody)
 	if err != nil {
 		return err
 	}
@@ -118,7 +118,7 @@ func (s *streamkapAPI) UpdateDestination(ctx context.Context, destinationID stri
 		return nil, err
 	}
 	req, err := http.NewRequestWithContext(
-		ctx, http.MethodPut, s.cfg.BaseURL+"/destinations/"+destinationID+"?secret_returned=true", bytes.NewBuffer(payload))
+		ctx, http.MethodPut, s.cfg.BaseURL+"/destinations/"+destinationID+"?secret_returned=true&wait=false", bytes.NewBuffer(payload))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/api/source.go
+++ b/internal/api/source.go
@@ -44,7 +44,7 @@ func (s *streamkapAPI) CreateSource(ctx context.Context, reqPayload Source) (*So
 		return nil, err
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, s.cfg.BaseURL+"/sources?secret_returned=true", bytes.NewBuffer(payload))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, s.cfg.BaseURL+"/sources?secret_returned=true&wait=false", bytes.NewBuffer(payload))
 	if err != nil {
 		return nil, err
 	}
@@ -92,7 +92,7 @@ func (s *streamkapAPI) GetSource(ctx context.Context, sourceID string) (*Source,
 }
 
 func (s *streamkapAPI) DeleteSource(ctx context.Context, sourceID string) error {
-	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, s.cfg.BaseURL+"/sources/"+sourceID+"?secret_returned=true", http.NoBody)
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, s.cfg.BaseURL+"/sources/"+sourceID+"?secret_returned=true&wait=false", http.NoBody)
 	if err != nil {
 		return err
 	}
@@ -118,7 +118,7 @@ func (s *streamkapAPI) UpdateSource(ctx context.Context, sourceID string, reqPay
 		return nil, err
 	}
 	req, err := http.NewRequestWithContext(
-		ctx, http.MethodPut, s.cfg.BaseURL+"/sources/"+sourceID+"?secret_returned=true", bytes.NewBuffer(payload))
+		ctx, http.MethodPut, s.cfg.BaseURL+"/sources/"+sourceID+"?secret_returned=true&wait=false", bytes.NewBuffer(payload))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/api/source.go
+++ b/internal/api/source.go
@@ -19,10 +19,11 @@ type GetSourceResponse struct {
 }
 
 type Source struct {
-	ID        string         `json:"id,omitempty"`
-	Name      string         `json:"name"`
-	Connector string         `json:"connector"`
-	Config    map[string]any `json:"config"`
+	ID          string         `json:"id,omitempty"`
+	Name        string         `json:"name"`
+	Connector   string         `json:"connector"`
+	Config      map[string]any `json:"config"`
+	KcClusterId *string        `json:"kc_cluster_id,omitempty"`
 }
 
 func (s *streamkapAPI) CreateSource(ctx context.Context, reqPayload Source) (*Source, error) {

--- a/internal/api/transform.go
+++ b/internal/api/transform.go
@@ -1,11 +1,14 @@
 package api
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 
 	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/streamkap-com/terraform-provider-streamkap/internal/constants"
 )
 
 type GetTransformResponse struct {
@@ -16,11 +19,17 @@ type GetTransformResponse struct {
 }
 
 type Transform struct {
-	ID        string   `json:"id,omitempty"`
-	Name      string   `json:"name"`
-	StartTime *string  `json:"start_time"`
-	TopicIDs  []string `json:"topic_ids"`
-	Topics    []string `json:"topics"`
+	ID              string         `json:"id,omitempty"`
+	Name            string         `json:"name"`
+	TransformType   string         `json:"transform_type"`
+	StartTime       *string        `json:"start_time"`
+	TopicIDs        []string       `json:"topic_ids"`
+	Topics          []string       `json:"topics"`
+	Config          map[string]any `json:"config,omitempty"`
+	Implementation  map[string]any `json:"implementation,omitempty"`
+	LiveVersion     *string        `json:"live_version,omitempty"`
+	PreviewVersion  *string        `json:"preview_version,omitempty"`
+	JobName         *string        `json:"job_name,omitempty"`
 }
 
 func (s *streamkapAPI) GetTransform(ctx context.Context, TransformID string) (*Transform, error) {
@@ -46,4 +55,131 @@ func (s *streamkapAPI) GetTransform(ctx context.Context, TransformID string) (*T
 	}
 
 	return &resp.Result[0], nil
+}
+
+func (s *streamkapAPI) CreateTransform(ctx context.Context, reqPayload Transform) (*Transform, error) {
+	payload, err := json.Marshal(reqPayload)
+	if err != nil {
+		return nil, err
+	}
+
+	var payloadMap map[string]any
+	err = json.Unmarshal(payload, &payloadMap)
+	if err != nil {
+		return nil, err
+	}
+
+	payloadMap["created_from"] = constants.TERRAFORM
+	// Backend expects "transform" field for library type
+	payloadMap["transform"] = reqPayload.TransformType
+
+	payload, err = json.Marshal(payloadMap)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, s.cfg.BaseURL+"/transforms?secret_returned=true", bytes.NewBuffer(payload))
+	if err != nil {
+		return nil, err
+	}
+	tflog.Debug(ctx, fmt.Sprintf(
+		"CreateTransform request details:\n"+
+			"\tMethod: %s\n"+
+			"\tURL: %s\n"+
+			"\tBody: %s",
+		req.Method,
+		req.URL.String(),
+		payload,
+	))
+	var resp Transform
+	err = s.doRequest(ctx, req, &resp)
+	if err != nil {
+		return nil, err
+	}
+
+	return &resp, nil
+}
+
+func (s *streamkapAPI) UpdateTransform(ctx context.Context, transformID string, reqPayload Transform) (*Transform, error) {
+	reqPayload.ID = transformID
+	payload, err := json.Marshal(reqPayload)
+	if err != nil {
+		return nil, err
+	}
+
+	var payloadMap map[string]any
+	err = json.Unmarshal(payload, &payloadMap)
+	if err != nil {
+		return nil, err
+	}
+
+	payloadMap["transform"] = reqPayload.TransformType
+
+	payload, err = json.Marshal(payloadMap)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, s.cfg.BaseURL+"/transforms?secret_returned=true", bytes.NewBuffer(payload))
+	if err != nil {
+		return nil, err
+	}
+	tflog.Debug(ctx, fmt.Sprintf(
+		"UpdateTransform request details:\n"+
+			"\tMethod: %s\n"+
+			"\tURL: %s\n"+
+			"\tBody: %s",
+		req.Method,
+		req.URL.String(),
+		payload,
+	))
+	var resp Transform
+	err = s.doRequest(ctx, req, &resp)
+	if err != nil {
+		return nil, err
+	}
+
+	return &resp, nil
+}
+
+func (s *streamkapAPI) DeleteTransform(ctx context.Context, transformID string) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, s.cfg.BaseURL+"/transforms?id="+transformID, http.NoBody)
+	if err != nil {
+		return err
+	}
+	tflog.Debug(ctx, fmt.Sprintf(
+		"DeleteTransform request details:\n"+
+			"\tMethod: %s\n"+
+			"\tURL: %s\n",
+		req.Method,
+		req.URL.String(),
+	))
+	var resp Transform
+	err = s.doRequest(ctx, req, &resp)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (s *streamkapAPI) DeployTransformLive(ctx context.Context, transformID string, versionID string) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, s.cfg.BaseURL+"/transforms/"+transformID+"/deploy-job-live/"+versionID, http.NoBody)
+	if err != nil {
+		return err
+	}
+	tflog.Debug(ctx, fmt.Sprintf(
+		"DeployTransformLive request details:\n"+
+			"\tMethod: %s\n"+
+			"\tURL: %s\n",
+		req.Method,
+		req.URL.String(),
+	))
+	var resp map[string]any
+	err = s.doRequest(ctx, req, &resp)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -20,6 +20,7 @@ import (
 	"github.com/streamkap-com/terraform-provider-streamkap/internal/resource/pipeline"
 	"github.com/streamkap-com/terraform-provider-streamkap/internal/resource/source"
 	"github.com/streamkap-com/terraform-provider-streamkap/internal/resource/topic"
+	"github.com/streamkap-com/terraform-provider-streamkap/internal/resource/transform"
 )
 
 // Ensure the implementation satisfies the expected interfaces.
@@ -222,5 +223,6 @@ func (p *streamkapProvider) Resources(_ context.Context) []func() resource.Resou
 		destination.NewDestinationKafkaResource,
 		pipeline.NewPipelineResource,
 		topic.NewTopicResource,
+		transform.NewTransformTopicRouterResource,
 	}
 }

--- a/internal/resource/destination/clickhouse.go
+++ b/internal/resource/destination/clickhouse.go
@@ -239,9 +239,10 @@ func (r *DestinationClickHouseResource) Create(ctx context.Context, req res.Crea
 
 	tflog.Debug(ctx, "Pre CREATE ===> config: "+fmt.Sprintf("%+v", config))
 	destination, err := r.client.CreateDestination(ctx, api.Destination{
-		Name:      plan.Name.ValueString(),
-		Connector: plan.Connector.ValueString(),
-		Config:    config,
+		Name:        plan.Name.ValueString(),
+		Connector:   plan.Connector.ValueString(),
+		Config:      config,
+		KcClusterId: plan.KcClusterId.ValueStringPointer(),
 	})
 	if err != nil {
 		resp.Diagnostics.AddError(
@@ -295,6 +296,11 @@ func (r *DestinationClickHouseResource) Read(ctx context.Context, req res.ReadRe
 	state.Name = types.StringValue(destination.Name)
 	state.Connector = types.StringValue(destination.Connector)
 	r.configMap2Model(destination.Config, &state)
+	if destination.KcClusterId != nil {
+		state.KcClusterId = types.StringValue(*destination.KcClusterId)
+	} else {
+		state.KcClusterId = types.StringNull()
+	}
 	tflog.Info(ctx, "===> config: "+fmt.Sprintf("%+v", state))
 
 	// Save updated data into Terraform state
@@ -323,9 +329,10 @@ func (r *DestinationClickHouseResource) Update(ctx context.Context, req res.Upda
 	}
 
 	destination, err := r.client.UpdateDestination(ctx, plan.ID.ValueString(), api.Destination{
-		Name:      plan.Name.ValueString(),
-		Connector: plan.Connector.ValueString(),
-		Config:    config,
+		Name:        plan.Name.ValueString(),
+		Connector:   plan.Connector.ValueString(),
+		Config:      config,
+		KcClusterId: plan.KcClusterId.ValueStringPointer(),
 	})
 	if err != nil {
 		resp.Diagnostics.AddError(
@@ -420,7 +427,6 @@ func (r *DestinationClickHouseResource) model2ConfigMap(model DestinationClickHo
 		"topics.config.map": topicsConfigMapStr,
 		"schema.evolution":  model.SchemaEvolution.ValueString(),
 		"quote.identifiers": model.QuoteIdentifiers.ValueBool(),
-		"kc.cluster.id":     model.KcClusterId.ValueStringPointer(),
 	}, nil
 }
 
@@ -438,7 +444,6 @@ func (r *DestinationClickHouseResource) configMap2Model(cfg map[string]any, mode
 	model.SSL = helper.GetTfCfgBool(cfg, "ssl")
 	model.SchemaEvolution = helper.GetTfCfgString(cfg, "schema.evolution")
 	model.QuoteIdentifiers = helper.GetTfCfgBool(cfg, "quote.identifiers")
-	model.KcClusterId = helper.GetTfCfgString(cfg, "kc.cluster.id")
 
 	// Parse topics config map
 	// Example:

--- a/internal/resource/destination/clickhouse.go
+++ b/internal/resource/destination/clickhouse.go
@@ -58,6 +58,7 @@ type DestinationClickHouseResourceModel struct {
 	TopicsConfigMap    map[string]clickHouseTopicsConfigMapItemModel `tfsdk:"topics_config_map"`
 	SchemaEvolution    types.String                                  `tfsdk:"schema_evolution"`
 	QuoteIdentifiers   types.Bool                                    `tfsdk:"quote_identifiers"`
+	KcClusterId        types.String                                  `tfsdk:"kc_cluster_id"`
 }
 
 type clickHouseTopicsConfigMapItemModel struct {
@@ -188,6 +189,10 @@ func (r *DestinationClickHouseResource) Schema(ctx context.Context, req res.Sche
 				Default:             booldefault.StaticBool(false),
 				Description:         "Whether to quote identifiers in SQL statements",
 				MarkdownDescription: "Whether to quote identifiers in SQL statements",
+			},
+			"kc_cluster_id": schema.StringAttribute{
+				Optional:    true,
+				Description: "KC cluster ID to deploy this connector to. Omit for default cluster.",
 			},
 		},
 	}
@@ -415,6 +420,7 @@ func (r *DestinationClickHouseResource) model2ConfigMap(model DestinationClickHo
 		"topics.config.map": topicsConfigMapStr,
 		"schema.evolution":  model.SchemaEvolution.ValueString(),
 		"quote.identifiers": model.QuoteIdentifiers.ValueBool(),
+		"kc.cluster.id":     model.KcClusterId.ValueStringPointer(),
 	}, nil
 }
 
@@ -432,6 +438,7 @@ func (r *DestinationClickHouseResource) configMap2Model(cfg map[string]any, mode
 	model.SSL = helper.GetTfCfgBool(cfg, "ssl")
 	model.SchemaEvolution = helper.GetTfCfgString(cfg, "schema.evolution")
 	model.QuoteIdentifiers = helper.GetTfCfgBool(cfg, "quote.identifiers")
+	model.KcClusterId = helper.GetTfCfgString(cfg, "kc.cluster.id")
 
 	// Parse topics config map
 	// Example:

--- a/internal/resource/destination/databricks.go
+++ b/internal/resource/destination/databricks.go
@@ -55,6 +55,7 @@ type DestinationDatabricksResourceModel struct {
 	TasksMax                         types.Int64  `tfsdk:"tasks_max"`
 	ConsumerWaitTimeForLargerBatchMs types.Int64  `tfsdk:"consumer_wait_time_for_larger_batch_ms"`
 	QuoteIdentifiers                 types.Bool   `tfsdk:"quote_identifiers"`
+	KcClusterId                      types.String `tfsdk:"kc_cluster_id"`
 }
 
 func (r *DestinationDatabricksResource) Metadata(ctx context.Context, req res.MetadataRequest, resp *res.MetadataResponse) {
@@ -181,6 +182,10 @@ func (r *DestinationDatabricksResource) Schema(ctx context.Context, req res.Sche
 				Default:             booldefault.StaticBool(true),
 				Description:         "Whether to quote identifiers in SQL statements",
 				MarkdownDescription: "Whether to quote identifiers in SQL statements",
+			},
+			"kc_cluster_id": schema.StringAttribute{
+				Optional:    true,
+				Description: "KC cluster ID to deploy this connector to. Omit for default cluster.",
 			},
 		},
 	}
@@ -364,6 +369,7 @@ func (r *DestinationDatabricksResource) model2ConfigMap(_ context.Context, model
 		"tasks.max":                              model.TasksMax.ValueInt64(),
 		"consumer.wait.time.for.larger.batch.ms": model.ConsumerWaitTimeForLargerBatchMs.ValueInt64(),
 		"quote.identifiers":                      model.QuoteIdentifiers.ValueBool(),
+		"kc.cluster.id":                          model.KcClusterId.ValueStringPointer(),
 	}
 
 	return configMap
@@ -382,4 +388,5 @@ func (r *DestinationDatabricksResource) configMap2Model(ctx context.Context, cfg
 	model.TasksMax = helper.GetTfCfgInt64(cfg, "tasks.max")
 	model.ConsumerWaitTimeForLargerBatchMs = helper.GetTfCfgInt64(cfg, "consumer.wait.time.for.larger.batch.ms")
 	model.QuoteIdentifiers = helper.GetTfCfgBool(cfg, "quote.identifiers")
+	model.KcClusterId = helper.GetTfCfgString(cfg, "kc.cluster.id")
 }

--- a/internal/resource/destination/databricks.go
+++ b/internal/resource/destination/databricks.go
@@ -225,9 +225,10 @@ func (r *DestinationDatabricksResource) Create(ctx context.Context, req res.Crea
 
 	tflog.Debug(ctx, "Pre CREATE ===> config: "+fmt.Sprintf("%+v", config))
 	destination, err := r.client.CreateDestination(ctx, api.Destination{
-		Name:      plan.Name.ValueString(),
-		Connector: plan.Connector.ValueString(),
-		Config:    config,
+		Name:        plan.Name.ValueString(),
+		Connector:   plan.Connector.ValueString(),
+		Config:      config,
+		KcClusterId: plan.KcClusterId.ValueStringPointer(),
 	})
 
 	if err != nil {
@@ -282,6 +283,11 @@ func (r *DestinationDatabricksResource) Read(ctx context.Context, req res.ReadRe
 	state.Name = types.StringValue(destination.Name)
 	state.Connector = types.StringValue(destination.Connector)
 	r.configMap2Model(ctx, destination.Config, &state)
+	if destination.KcClusterId != nil {
+		state.KcClusterId = types.StringValue(*destination.KcClusterId)
+	} else {
+		state.KcClusterId = types.StringNull()
+	}
 
 	// Save updated data into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
@@ -304,9 +310,10 @@ func (r *DestinationDatabricksResource) Update(ctx context.Context, req res.Upda
 
 	tflog.Debug(ctx, "Pre UPDATE ===> config: "+fmt.Sprintf("%+v", config))
 	destination, err := r.client.UpdateDestination(ctx, plan.ID.ValueString(), api.Destination{
-		Name:      plan.Name.ValueString(),
-		Connector: plan.Connector.ValueString(),
-		Config:    config,
+		Name:        plan.Name.ValueString(),
+		Connector:   plan.Connector.ValueString(),
+		Config:      config,
+		KcClusterId: plan.KcClusterId.ValueStringPointer(),
 	})
 
 	if err != nil {
@@ -369,7 +376,6 @@ func (r *DestinationDatabricksResource) model2ConfigMap(_ context.Context, model
 		"tasks.max":                              model.TasksMax.ValueInt64(),
 		"consumer.wait.time.for.larger.batch.ms": model.ConsumerWaitTimeForLargerBatchMs.ValueInt64(),
 		"quote.identifiers":                      model.QuoteIdentifiers.ValueBool(),
-		"kc.cluster.id":                          model.KcClusterId.ValueStringPointer(),
 	}
 
 	return configMap
@@ -388,5 +394,4 @@ func (r *DestinationDatabricksResource) configMap2Model(ctx context.Context, cfg
 	model.TasksMax = helper.GetTfCfgInt64(cfg, "tasks.max")
 	model.ConsumerWaitTimeForLargerBatchMs = helper.GetTfCfgInt64(cfg, "consumer.wait.time.for.larger.batch.ms")
 	model.QuoteIdentifiers = helper.GetTfCfgBool(cfg, "quote.identifiers")
-	model.KcClusterId = helper.GetTfCfgString(cfg, "kc.cluster.id")
 }

--- a/internal/resource/destination/iceberg.go
+++ b/internal/resource/destination/iceberg.go
@@ -54,6 +54,7 @@ type DestinationIcebergResourceModel struct {
 	InsertMode       types.String `tfsdk:"insert_mode"`
 	PrimaryKeyFields types.String `tfsdk:"primary_key_fields"`
 	QuoteIdentifiers types.Bool   `tfsdk:"quote_identifiers"`
+	KcClusterId      types.String `tfsdk:"kc_cluster_id"`
 }
 
 func (r *DestinationIcebergResource) Metadata(ctx context.Context, req res.MetadataRequest, resp *res.MetadataResponse) {
@@ -185,6 +186,10 @@ func (r *DestinationIcebergResource) Schema(ctx context.Context, req res.SchemaR
 				Default:             booldefault.StaticBool(true),
 				Description:         "Whether to quote identifiers in SQL statements",
 				MarkdownDescription: "Whether to quote identifiers in SQL statements",
+			},
+			"kc_cluster_id": schema.StringAttribute{
+				Optional:    true,
+				Description: "KC cluster ID to deploy this connector to. Omit for default cluster.",
 			},
 		},
 	}
@@ -363,6 +368,7 @@ func (r *DestinationIcebergResource) model2ConfigMap(model DestinationIcebergRes
 		"insert.mode.user.defined":                   model.InsertMode.ValueString(),
 		"iceberg.tables.default-id-columns":          model.PrimaryKeyFields.ValueString(),
 		"quote.identifiers":                          model.QuoteIdentifiers.ValueBool(),
+		"kc.cluster.id":                              model.KcClusterId.ValueStringPointer(),
 	}
 
 	return configMap
@@ -382,4 +388,5 @@ func (r *DestinationIcebergResource) configMap2Model(cfg map[string]any, model *
 	model.InsertMode = helper.GetTfCfgString(cfg, "insert.mode.user.defined")
 	model.PrimaryKeyFields = helper.GetTfCfgString(cfg, "iceberg.tables.default-id-columns")
 	model.QuoteIdentifiers = helper.GetTfCfgBool(cfg, "quote.identifiers")
+	model.KcClusterId = helper.GetTfCfgString(cfg, "kc.cluster.id")
 }

--- a/internal/resource/destination/iceberg.go
+++ b/internal/resource/destination/iceberg.go
@@ -229,9 +229,10 @@ func (r *DestinationIcebergResource) Create(ctx context.Context, req res.CreateR
 
 	tflog.Debug(ctx, "Pre CREATE ===> config: "+fmt.Sprintf("%+v", config))
 	destination, err := r.client.CreateDestination(ctx, api.Destination{
-		Name:      plan.Name.ValueString(),
-		Connector: plan.Connector.ValueString(),
-		Config:    config,
+		Name:        plan.Name.ValueString(),
+		Connector:   plan.Connector.ValueString(),
+		Config:      config,
+		KcClusterId: plan.KcClusterId.ValueStringPointer(),
 	})
 	if err != nil {
 		resp.Diagnostics.AddError(
@@ -285,6 +286,11 @@ func (r *DestinationIcebergResource) Read(ctx context.Context, req res.ReadReque
 	state.Name = types.StringValue(destination.Name)
 	state.Connector = types.StringValue(destination.Connector)
 	r.configMap2Model(destination.Config, &state, ctx)
+	if destination.KcClusterId != nil {
+		state.KcClusterId = types.StringValue(*destination.KcClusterId)
+	} else {
+		state.KcClusterId = types.StringNull()
+	}
 	tflog.Info(ctx, "===> config: "+fmt.Sprintf("%+v", state))
 
 	// Save updated data into Terraform state
@@ -306,9 +312,10 @@ func (r *DestinationIcebergResource) Update(ctx context.Context, req res.UpdateR
 	config := r.model2ConfigMap(plan)
 
 	destination, err := r.client.UpdateDestination(ctx, plan.ID.ValueString(), api.Destination{
-		Name:      plan.Name.ValueString(),
-		Connector: plan.Connector.ValueString(),
-		Config:    config,
+		Name:        plan.Name.ValueString(),
+		Connector:   plan.Connector.ValueString(),
+		Config:      config,
+		KcClusterId: plan.KcClusterId.ValueStringPointer(),
 	})
 	if err != nil {
 		resp.Diagnostics.AddError(
@@ -368,7 +375,6 @@ func (r *DestinationIcebergResource) model2ConfigMap(model DestinationIcebergRes
 		"insert.mode.user.defined":                   model.InsertMode.ValueString(),
 		"iceberg.tables.default-id-columns":          model.PrimaryKeyFields.ValueString(),
 		"quote.identifiers":                          model.QuoteIdentifiers.ValueBool(),
-		"kc.cluster.id":                              model.KcClusterId.ValueStringPointer(),
 	}
 
 	return configMap
@@ -388,5 +394,4 @@ func (r *DestinationIcebergResource) configMap2Model(cfg map[string]any, model *
 	model.InsertMode = helper.GetTfCfgString(cfg, "insert.mode.user.defined")
 	model.PrimaryKeyFields = helper.GetTfCfgString(cfg, "iceberg.tables.default-id-columns")
 	model.QuoteIdentifiers = helper.GetTfCfgBool(cfg, "quote.identifiers")
-	model.KcClusterId = helper.GetTfCfgString(cfg, "kc.cluster.id")
 }

--- a/internal/resource/destination/kafka.go
+++ b/internal/resource/destination/kafka.go
@@ -52,6 +52,7 @@ type DestinationKafkaResourceModel struct {
 	TopicSuffix        types.String `tfsdk:"topic_suffix"`
 	TasksMax           types.Int64  `tfsdk:"tasks_max"`
 	OffsetField        types.String `tfsdk:"offset_field"`
+	AddOriginalTopic   types.String `tfsdk:"add_original_topic"`
 }
 
 func (r *DestinationKafkaResource) Metadata(ctx context.Context, req res.MetadataRequest, resp *res.MetadataResponse) {
@@ -141,6 +142,20 @@ func (r *DestinationKafkaResource) Schema(ctx context.Context, req res.SchemaReq
 				Default:             stringdefault.StaticString("_streamkap_offset"),
 				Description:         "Streamkap offset metadata field name. Rename to _streamkap_offset_sync or _streamkap_offset_transform to avoid conflicts when using Kafka destination to sync data between services or apply transformations.",
 				MarkdownDescription: "Streamkap offset metadata field name. Rename to `_streamkap_offset_sync` or `_streamkap_offset_transform` to avoid conflicts when using Kafka destination to sync data between services or apply transformations.",
+			},
+			"add_original_topic": schema.StringAttribute{
+				Computed:            true,
+				Optional:            true,
+				Default:             stringdefault.StaticString("off"),
+				Description:         "Add the original topic name to the output record. 'off' disables it, 'header' adds it as a Kafka header, 'field' adds it as a _streamkap_topic column in the destination table.",
+				MarkdownDescription: "Add the original topic name to the output record. `off` disables it, `header` adds it as a Kafka header, `field` adds it as a `_streamkap_topic` column in the destination table.",
+				Validators: []validator.String{
+					stringvalidator.OneOf(
+						"off",
+						"header",
+						"field",
+					),
+				},
 			},
 		},
 	}
@@ -329,7 +344,8 @@ func (r *DestinationKafkaResource) model2ConfigMap(model DestinationKafkaResourc
 		"topic.prefix":                     model.TopicPrefix.ValueString(),
 		"topic.suffix":                     model.TopicSuffix.ValueString(),
 		"tasks.max":                        model.TasksMax.ValueInt64(),
-		"transforms.InsertField.offset.field": model.OffsetField.ValueString(),
+		"transforms.InsertField.offset.field":            model.OffsetField.ValueString(),
+		"transforms.changeTopicName.add.original.topic": model.AddOriginalTopic.ValueString(),
 	}, nil
 }
 
@@ -343,4 +359,5 @@ func (r *DestinationKafkaResource) configMap2Model(cfg map[string]any, model *De
 	model.TopicSuffix = helper.GetTfCfgString(cfg, "topic.suffix")
 	model.TasksMax = helper.GetTfCfgInt64(cfg, "tasks.max")
 	model.OffsetField = helper.GetTfCfgString(cfg, "transforms.InsertField.offset.field")
+	model.AddOriginalTopic = helper.GetTfCfgString(cfg, "transforms.changeTopicName.add.original.topic")
 }

--- a/internal/resource/destination/kafka.go
+++ b/internal/resource/destination/kafka.go
@@ -51,6 +51,7 @@ type DestinationKafkaResourceModel struct {
 	TopicPrefix        types.String `tfsdk:"topic_prefix"`
 	TopicSuffix        types.String `tfsdk:"topic_suffix"`
 	TasksMax           types.Int64  `tfsdk:"tasks_max"`
+	OffsetField        types.String `tfsdk:"offset_field"`
 }
 
 func (r *DestinationKafkaResource) Metadata(ctx context.Context, req res.MetadataRequest, resp *res.MetadataResponse) {
@@ -133,6 +134,13 @@ func (r *DestinationKafkaResource) Schema(ctx context.Context, req res.SchemaReq
 				Validators: []validator.Int64{
 					int64validator.Between(1, 100),
 				},
+			},
+			"offset_field": schema.StringAttribute{
+				Computed:            true,
+				Optional:            true,
+				Default:             stringdefault.StaticString("_streamkap_offset"),
+				Description:         "Streamkap offset metadata field name. Rename to _streamkap_offset_sync or _streamkap_offset_transform to avoid conflicts when using Kafka destination to sync data between services or apply transformations.",
+				MarkdownDescription: "Streamkap offset metadata field name. Rename to `_streamkap_offset_sync` or `_streamkap_offset_transform` to avoid conflicts when using Kafka destination to sync data between services or apply transformations.",
 			},
 		},
 	}
@@ -321,6 +329,7 @@ func (r *DestinationKafkaResource) model2ConfigMap(model DestinationKafkaResourc
 		"topic.prefix":                     model.TopicPrefix.ValueString(),
 		"topic.suffix":                     model.TopicSuffix.ValueString(),
 		"tasks.max":                        model.TasksMax.ValueInt64(),
+		"transforms.InsertField.offset.field": model.OffsetField.ValueString(),
 	}, nil
 }
 
@@ -333,4 +342,5 @@ func (r *DestinationKafkaResource) configMap2Model(cfg map[string]any, model *De
 	model.TopicPrefix = helper.GetTfCfgString(cfg, "topic.prefix")
 	model.TopicSuffix = helper.GetTfCfgString(cfg, "topic.suffix")
 	model.TasksMax = helper.GetTfCfgInt64(cfg, "tasks.max")
+	model.OffsetField = helper.GetTfCfgString(cfg, "transforms.InsertField.offset.field")
 }

--- a/internal/resource/destination/kafka.go
+++ b/internal/resource/destination/kafka.go
@@ -53,6 +53,7 @@ type DestinationKafkaResourceModel struct {
 	TasksMax           types.Int64  `tfsdk:"tasks_max"`
 	OffsetField        types.String `tfsdk:"offset_field"`
 	AddOriginalTopic   types.String `tfsdk:"add_original_topic"`
+	KcClusterId        types.String `tfsdk:"kc_cluster_id"`
 }
 
 func (r *DestinationKafkaResource) Metadata(ctx context.Context, req res.MetadataRequest, resp *res.MetadataResponse) {
@@ -156,6 +157,10 @@ func (r *DestinationKafkaResource) Schema(ctx context.Context, req res.SchemaReq
 						"field",
 					),
 				},
+			},
+			"kc_cluster_id": schema.StringAttribute{
+				Optional:    true,
+				Description: "KC cluster ID to deploy this connector to. Omit for default cluster.",
 			},
 		},
 	}
@@ -346,6 +351,7 @@ func (r *DestinationKafkaResource) model2ConfigMap(model DestinationKafkaResourc
 		"tasks.max":                        model.TasksMax.ValueInt64(),
 		"transforms.InsertField.offset.field":            model.OffsetField.ValueString(),
 		"transforms.changeTopicName.add.original.topic": model.AddOriginalTopic.ValueString(),
+		"kc.cluster.id": model.KcClusterId.ValueStringPointer(),
 	}, nil
 }
 
@@ -360,4 +366,5 @@ func (r *DestinationKafkaResource) configMap2Model(cfg map[string]any, model *De
 	model.TasksMax = helper.GetTfCfgInt64(cfg, "tasks.max")
 	model.OffsetField = helper.GetTfCfgString(cfg, "transforms.InsertField.offset.field")
 	model.AddOriginalTopic = helper.GetTfCfgString(cfg, "transforms.changeTopicName.add.original.topic")
+	model.KcClusterId = helper.GetTfCfgString(cfg, "kc.cluster.id")
 }

--- a/internal/resource/destination/kafka.go
+++ b/internal/resource/destination/kafka.go
@@ -207,9 +207,10 @@ func (r *DestinationKafkaResource) Create(ctx context.Context, req res.CreateReq
 
 	tflog.Debug(ctx, "Pre CREATE ===> config: "+fmt.Sprintf("%+v", config))
 	destination, err := r.client.CreateDestination(ctx, api.Destination{
-		Name:      plan.Name.ValueString(),
-		Connector: plan.Connector.ValueString(),
-		Config:    config,
+		Name:        plan.Name.ValueString(),
+		Connector:   plan.Connector.ValueString(),
+		Config:      config,
+		KcClusterId: plan.KcClusterId.ValueStringPointer(),
 	})
 	if err != nil {
 		resp.Diagnostics.AddError(
@@ -263,6 +264,11 @@ func (r *DestinationKafkaResource) Read(ctx context.Context, req res.ReadRequest
 	state.Name = types.StringValue(destination.Name)
 	state.Connector = types.StringValue(destination.Connector)
 	r.configMap2Model(destination.Config, &state)
+	if destination.KcClusterId != nil {
+		state.KcClusterId = types.StringValue(*destination.KcClusterId)
+	} else {
+		state.KcClusterId = types.StringNull()
+	}
 	tflog.Info(ctx, "===> config: "+fmt.Sprintf("%+v", state))
 
 	// Save updated data into Terraform state
@@ -291,9 +297,10 @@ func (r *DestinationKafkaResource) Update(ctx context.Context, req res.UpdateReq
 	}
 
 	destination, err := r.client.UpdateDestination(ctx, plan.ID.ValueString(), api.Destination{
-		Name:      plan.Name.ValueString(),
-		Connector: plan.Connector.ValueString(),
-		Config:    config,
+		Name:        plan.Name.ValueString(),
+		Connector:   plan.Connector.ValueString(),
+		Config:      config,
+		KcClusterId: plan.KcClusterId.ValueStringPointer(),
 	})
 	if err != nil {
 		resp.Diagnostics.AddError(
@@ -351,7 +358,6 @@ func (r *DestinationKafkaResource) model2ConfigMap(model DestinationKafkaResourc
 		"tasks.max":                        model.TasksMax.ValueInt64(),
 		"transforms.InsertField.offset.field":            model.OffsetField.ValueString(),
 		"transforms.changeTopicName.add.original.topic": model.AddOriginalTopic.ValueString(),
-		"kc.cluster.id": model.KcClusterId.ValueStringPointer(),
 	}, nil
 }
 
@@ -366,5 +372,4 @@ func (r *DestinationKafkaResource) configMap2Model(cfg map[string]any, model *De
 	model.TasksMax = helper.GetTfCfgInt64(cfg, "tasks.max")
 	model.OffsetField = helper.GetTfCfgString(cfg, "transforms.InsertField.offset.field")
 	model.AddOriginalTopic = helper.GetTfCfgString(cfg, "transforms.changeTopicName.add.original.topic")
-	model.KcClusterId = helper.GetTfCfgString(cfg, "kc.cluster.id")
 }

--- a/internal/resource/destination/postgresql.go
+++ b/internal/resource/destination/postgresql.go
@@ -61,6 +61,7 @@ type DestinationPostgresqlResourceModel struct {
 	SSHPort            types.String `tfsdk:"ssh_port"`
 	SSHUser            types.String `tfsdk:"ssh_user"`
 	QuoteIdentifiers   types.Bool   `tfsdk:"quote_identifiers"`
+	KcClusterId        types.String `tfsdk:"kc_cluster_id"`
 }
 
 func (r *DestinationPostgresqlResource) Metadata(ctx context.Context, req res.MetadataRequest, resp *res.MetadataResponse) {
@@ -219,6 +220,10 @@ func (r *DestinationPostgresqlResource) Schema(ctx context.Context, req res.Sche
 				Default:             booldefault.StaticBool(true),
 				Description:         "Whether to quote identifiers in SQL statements",
 				MarkdownDescription: "Whether to quote identifiers in SQL statements",
+			},
+			"kc_cluster_id": schema.StringAttribute{
+				Optional:    true,
+				Description: "KC cluster ID to deploy this connector to. Omit for default cluster.",
 			},
 		},
 	}
@@ -402,6 +407,7 @@ func (r *DestinationPostgresqlResource) model2ConfigMap(model DestinationPostgre
 		"ssh.port":                       model.SSHPort.ValueString(),
 		"ssh.user":                       model.SSHUser.ValueString(),
 		"quote.identifiers":              model.QuoteIdentifiers.ValueBool(),
+		"kc.cluster.id":                  model.KcClusterId.ValueStringPointer(),
 	}
 
 	return configMap
@@ -426,4 +432,5 @@ func (r *DestinationPostgresqlResource) configMap2Model(cfg map[string]any, mode
 	model.SSHPort = helper.GetTfCfgString(cfg, "ssh.port")
 	model.SSHUser = helper.GetTfCfgString(cfg, "ssh.user")
 	model.QuoteIdentifiers = helper.GetTfCfgBool(cfg, "quote.identifiers")
+	model.KcClusterId = helper.GetTfCfgString(cfg, "kc.cluster.id")
 }

--- a/internal/resource/destination/postgresql.go
+++ b/internal/resource/destination/postgresql.go
@@ -263,9 +263,10 @@ func (r *DestinationPostgresqlResource) Create(ctx context.Context, req res.Crea
 
 	tflog.Debug(ctx, "Pre CREATE ===> config: "+fmt.Sprintf("%+v", config))
 	destination, err := r.client.CreateDestination(ctx, api.Destination{
-		Name:      plan.Name.ValueString(),
-		Connector: plan.Connector.ValueString(),
-		Config:    config,
+		Name:        plan.Name.ValueString(),
+		Connector:   plan.Connector.ValueString(),
+		Config:      config,
+		KcClusterId: plan.KcClusterId.ValueStringPointer(),
 	})
 	if err != nil {
 		resp.Diagnostics.AddError(
@@ -319,6 +320,11 @@ func (r *DestinationPostgresqlResource) Read(ctx context.Context, req res.ReadRe
 	state.Name = types.StringValue(destination.Name)
 	state.Connector = types.StringValue(destination.Connector)
 	r.configMap2Model(destination.Config, &state)
+	if destination.KcClusterId != nil {
+		state.KcClusterId = types.StringValue(*destination.KcClusterId)
+	} else {
+		state.KcClusterId = types.StringNull()
+	}
 	tflog.Info(ctx, "===> config: "+fmt.Sprintf("%+v", state))
 
 	// Save updated data into Terraform state
@@ -340,9 +346,10 @@ func (r *DestinationPostgresqlResource) Update(ctx context.Context, req res.Upda
 	config := r.model2ConfigMap(plan)
 
 	destination, err := r.client.UpdateDestination(ctx, plan.ID.ValueString(), api.Destination{
-		Name:      plan.Name.ValueString(),
-		Connector: plan.Connector.ValueString(),
-		Config:    config,
+		Name:        plan.Name.ValueString(),
+		Connector:   plan.Connector.ValueString(),
+		Config:      config,
+		KcClusterId: plan.KcClusterId.ValueStringPointer(),
 	})
 	if err != nil {
 		resp.Diagnostics.AddError(
@@ -407,7 +414,6 @@ func (r *DestinationPostgresqlResource) model2ConfigMap(model DestinationPostgre
 		"ssh.port":                       model.SSHPort.ValueString(),
 		"ssh.user":                       model.SSHUser.ValueString(),
 		"quote.identifiers":              model.QuoteIdentifiers.ValueBool(),
-		"kc.cluster.id":                  model.KcClusterId.ValueStringPointer(),
 	}
 
 	return configMap
@@ -432,5 +438,4 @@ func (r *DestinationPostgresqlResource) configMap2Model(cfg map[string]any, mode
 	model.SSHPort = helper.GetTfCfgString(cfg, "ssh.port")
 	model.SSHUser = helper.GetTfCfgString(cfg, "ssh.user")
 	model.QuoteIdentifiers = helper.GetTfCfgBool(cfg, "quote.identifiers")
-	model.KcClusterId = helper.GetTfCfgString(cfg, "kc.cluster.id")
 }

--- a/internal/resource/destination/s3.go
+++ b/internal/resource/destination/s3.go
@@ -54,6 +54,7 @@ type DestinationS3ResourceModel struct {
 	FilenamePrefix   types.String `tfsdk:"filename_prefix"`
 	CompressionType  types.String `tfsdk:"compression_type"`
 	OutputFields     types.List   `tfsdk:"output_fields"`
+	KcClusterId      types.String `tfsdk:"kc_cluster_id"`
 }
 
 func (r *DestinationS3Resource) Metadata(ctx context.Context, req res.MetadataRequest, resp *res.MetadataResponse) {
@@ -188,6 +189,10 @@ func (r *DestinationS3Resource) Schema(ctx context.Context, req res.SchemaReques
 						),
 					)),
 				},
+			},
+			"kc_cluster_id": schema.StringAttribute{
+				Optional:    true,
+				Description: "KC cluster ID to deploy this connector to. Omit for default cluster.",
 			},
 		},
 	}
@@ -378,6 +383,7 @@ func (r *DestinationS3Resource) model2ConfigMap(model DestinationS3ResourceModel
 		"file.name.prefix":                  model.FilenamePrefix.ValueString(),
 		"file.compression.type":             model.CompressionType.ValueString(),
 		"format.output.fields.user.defined": outputFields,
+		"kc.cluster.id":                     model.KcClusterId.ValueStringPointer(),
 	}
 
 	return configMap, nil
@@ -394,4 +400,5 @@ func (r *DestinationS3Resource) configMap2Model(cfg map[string]any, model *Desti
 	model.FilenamePrefix = helper.GetTfCfgString(cfg, "file.name.prefix")
 	model.CompressionType = helper.GetTfCfgString(cfg, "file.compression.type")
 	model.OutputFields = helper.GetTfCfgListString(ctx, cfg, "format.output.fields.user.defined")
+	model.KcClusterId = helper.GetTfCfgString(cfg, "kc.cluster.id")
 }

--- a/internal/resource/destination/s3.go
+++ b/internal/resource/destination/s3.go
@@ -236,9 +236,10 @@ func (r *DestinationS3Resource) Create(ctx context.Context, req res.CreateReques
 
 	tflog.Debug(ctx, "Pre CREATE ===> config: "+fmt.Sprintf("%+v", config))
 	destination, err := r.client.CreateDestination(ctx, api.Destination{
-		Name:      plan.Name.ValueString(),
-		Connector: plan.Connector.ValueString(),
-		Config:    config,
+		Name:        plan.Name.ValueString(),
+		Connector:   plan.Connector.ValueString(),
+		Config:      config,
+		KcClusterId: plan.KcClusterId.ValueStringPointer(),
 	})
 	if err != nil {
 		resp.Diagnostics.AddError(
@@ -292,6 +293,11 @@ func (r *DestinationS3Resource) Read(ctx context.Context, req res.ReadRequest, r
 	state.Name = types.StringValue(destination.Name)
 	state.Connector = types.StringValue(destination.Connector)
 	r.configMap2Model(destination.Config, &state, ctx)
+	if destination.KcClusterId != nil {
+		state.KcClusterId = types.StringValue(*destination.KcClusterId)
+	} else {
+		state.KcClusterId = types.StringNull()
+	}
 	tflog.Info(ctx, "===> config: "+fmt.Sprintf("%+v", state))
 
 	// Save updated data into Terraform state
@@ -317,9 +323,10 @@ func (r *DestinationS3Resource) Update(ctx context.Context, req res.UpdateReques
 	}
 
 	destination, err := r.client.UpdateDestination(ctx, plan.ID.ValueString(), api.Destination{
-		Name:      plan.Name.ValueString(),
-		Connector: plan.Connector.ValueString(),
-		Config:    config,
+		Name:        plan.Name.ValueString(),
+		Connector:   plan.Connector.ValueString(),
+		Config:      config,
+		KcClusterId: plan.KcClusterId.ValueStringPointer(),
 	})
 	if err != nil {
 		resp.Diagnostics.AddError(
@@ -383,7 +390,6 @@ func (r *DestinationS3Resource) model2ConfigMap(model DestinationS3ResourceModel
 		"file.name.prefix":                  model.FilenamePrefix.ValueString(),
 		"file.compression.type":             model.CompressionType.ValueString(),
 		"format.output.fields.user.defined": outputFields,
-		"kc.cluster.id":                     model.KcClusterId.ValueStringPointer(),
 	}
 
 	return configMap, nil
@@ -400,5 +406,4 @@ func (r *DestinationS3Resource) configMap2Model(cfg map[string]any, model *Desti
 	model.FilenamePrefix = helper.GetTfCfgString(cfg, "file.name.prefix")
 	model.CompressionType = helper.GetTfCfgString(cfg, "file.compression.type")
 	model.OutputFields = helper.GetTfCfgListString(ctx, cfg, "format.output.fields.user.defined")
-	model.KcClusterId = helper.GetTfCfgString(cfg, "kc.cluster.id")
 }

--- a/internal/resource/destination/snowflake.go
+++ b/internal/resource/destination/snowflake.go
@@ -296,9 +296,10 @@ func (r *DestinationSnowflakeResource) Create(ctx context.Context, req res.Creat
 
 	tflog.Debug(ctx, "Pre CREATE ===> config: "+fmt.Sprintf("%+v", config))
 	destination, err := r.client.CreateDestination(ctx, api.Destination{
-		Name:      plan.Name.ValueString(),
-		Connector: plan.Connector.ValueString(),
-		Config:    config,
+		Name:        plan.Name.ValueString(),
+		Connector:   plan.Connector.ValueString(),
+		Config:      config,
+		KcClusterId: plan.KcClusterId.ValueStringPointer(),
 	})
 
 	if err != nil {
@@ -353,6 +354,11 @@ func (r *DestinationSnowflakeResource) Read(ctx context.Context, req res.ReadReq
 	state.Name = types.StringValue(destination.Name)
 	state.Connector = types.StringValue(destination.Connector)
 	r.configMap2Model(ctx, destination.Config, &state)
+	if destination.KcClusterId != nil {
+		state.KcClusterId = types.StringValue(*destination.KcClusterId)
+	} else {
+		state.KcClusterId = types.StringNull()
+	}
 
 	// Save updated data into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
@@ -375,9 +381,10 @@ func (r *DestinationSnowflakeResource) Update(ctx context.Context, req res.Updat
 
 	tflog.Debug(ctx, "Pre UPDATE ===> config: "+fmt.Sprintf("%+v", config))
 	destination, err := r.client.UpdateDestination(ctx, plan.ID.ValueString(), api.Destination{
-		Name:      plan.Name.ValueString(),
-		Connector: plan.Connector.ValueString(),
-		Config:    config,
+		Name:        plan.Name.ValueString(),
+		Connector:   plan.Connector.ValueString(),
+		Config:      config,
+		KcClusterId: plan.KcClusterId.ValueStringPointer(),
 	})
 
 	if err != nil {
@@ -462,7 +469,6 @@ func (r *DestinationSnowflakeResource) model2ConfigMap(_ context.Context, model 
 		"auto.qa.dedupe.table.mapping":             autoQADedupeTableMappingStr,
 		"snowflake.topic2table.map":                model.SnowflakeTopic2TableMap.ValueStringPointer(),
 		"quote.identifiers":                        model.QuoteIdentifiers.ValueBool(),
-		"kc.cluster.id":                            model.KcClusterId.ValueStringPointer(),
 	}
 
 	if model.SnowflakePrivateKeyPassphrase.IsNull() {
@@ -493,7 +499,6 @@ func (r *DestinationSnowflakeResource) configMap2Model(ctx context.Context, cfg 
 	model.SQLTableName = helper.GetTfCfgString(cfg, "sql.table.name")
 	model.SnowflakeTopic2TableMap = helper.GetTfCfgString(cfg, "snowflake.topic2table.map")
 	model.QuoteIdentifiers = helper.GetTfCfgBool(cfg, "quote.identifiers")
-	model.KcClusterId = helper.GetTfCfgString(cfg, "kc.cluster.id")
 
 	// Parse auto QA deduplication table mapping
 	// Example:

--- a/internal/resource/destination/snowflake.go
+++ b/internal/resource/destination/snowflake.go
@@ -63,6 +63,7 @@ type DestinationSnowflakeResourceModel struct {
 	AutoQADedupeTableMapping      map[string]types.String `tfsdk:"auto_qa_dedupe_table_mapping"`
 	SnowflakeTopic2TableMap       types.String            `tfsdk:"snowflake_topic2table_map"`
 	QuoteIdentifiers              types.Bool              `tfsdk:"quote_identifiers"`
+	KcClusterId                   types.String            `tfsdk:"kc_cluster_id"`
 }
 
 func (r *DestinationSnowflakeResource) Metadata(ctx context.Context, req res.MetadataRequest, resp *res.MetadataResponse) {
@@ -252,6 +253,10 @@ func (r *DestinationSnowflakeResource) Schema(ctx context.Context, req res.Schem
 				Default:             booldefault.StaticBool(true),
 				Description:         "Whether to quote identifiers in SQL statements",
 				MarkdownDescription: "Whether to quote identifiers in SQL statements",
+			},
+			"kc_cluster_id": schema.StringAttribute{
+				Optional:    true,
+				Description: "KC cluster ID to deploy this connector to. Omit for default cluster.",
 			},
 		},
 	}
@@ -457,6 +462,7 @@ func (r *DestinationSnowflakeResource) model2ConfigMap(_ context.Context, model 
 		"auto.qa.dedupe.table.mapping":             autoQADedupeTableMappingStr,
 		"snowflake.topic2table.map":                model.SnowflakeTopic2TableMap.ValueStringPointer(),
 		"quote.identifiers":                        model.QuoteIdentifiers.ValueBool(),
+		"kc.cluster.id":                            model.KcClusterId.ValueStringPointer(),
 	}
 
 	if model.SnowflakePrivateKeyPassphrase.IsNull() {
@@ -487,6 +493,7 @@ func (r *DestinationSnowflakeResource) configMap2Model(ctx context.Context, cfg 
 	model.SQLTableName = helper.GetTfCfgString(cfg, "sql.table.name")
 	model.SnowflakeTopic2TableMap = helper.GetTfCfgString(cfg, "snowflake.topic2table.map")
 	model.QuoteIdentifiers = helper.GetTfCfgBool(cfg, "quote.identifiers")
+	model.KcClusterId = helper.GetTfCfgString(cfg, "kc.cluster.id")
 
 	// Parse auto QA deduplication table mapping
 	// Example:

--- a/internal/resource/source/dynamodb.go
+++ b/internal/resource/source/dynamodb.go
@@ -57,6 +57,7 @@ type SourceDynamoDBResourceModel struct {
 	ArrayEncodingJson             types.Bool   `tfsdk:"array_encoding_json"`
 	StructEncodingJson            types.Bool   `tfsdk:"struct_encoding_json"`
 	TasksMax                      types.Int64  `tfsdk:"tasks_max"`
+	KcClusterId                   types.String `tfsdk:"kc_cluster_id"`
 }
 
 func (r *SourceDynamoDBResource) Metadata(ctx context.Context, req res.MetadataRequest, resp *res.MetadataResponse) {
@@ -183,6 +184,10 @@ func (r *SourceDynamoDBResource) Schema(ctx context.Context, req res.SchemaReque
 				Validators: []validator.Int64{
 					int64validator.Between(1, 40),
 				},
+			},
+			"kc_cluster_id": schema.StringAttribute{
+				Optional:    true,
+				Description: "KC cluster ID to deploy this connector to. Omit for default cluster.",
 			},
 		},
 	}
@@ -361,6 +366,7 @@ func (r *SourceDynamoDBResource) model2ConfigMap(model SourceDynamoDBResourceMod
 		"array.encoding.json":              model.ArrayEncodingJson.ValueBool(),
 		"struct.encoding.json":             model.StructEncodingJson.ValueBool(),
 		"tasks.max":                        model.TasksMax.ValueInt64(),
+		"kc.cluster.id":                    model.KcClusterId.ValueStringPointer(),
 	}
 }
 
@@ -381,4 +387,5 @@ func (r *SourceDynamoDBResource) configMap2Model(cfg map[string]any, model *Sour
 	model.ArrayEncodingJson = helper.GetTfCfgBool(cfg, "array.encoding.json")
 	model.StructEncodingJson = helper.GetTfCfgBool(cfg, "struct.encoding.json")
 	model.TasksMax = helper.GetTfCfgInt64(cfg, "tasks.max")
+	model.KcClusterId = helper.GetTfCfgString(cfg, "kc.cluster.id")
 }

--- a/internal/resource/source/dynamodb.go
+++ b/internal/resource/source/dynamodb.go
@@ -225,9 +225,10 @@ func (r *SourceDynamoDBResource) Create(ctx context.Context, req res.CreateReque
 	config := r.model2ConfigMap(plan)
 
 	source, err := r.client.CreateSource(ctx, api.Source{
-		Name:      plan.Name.ValueString(),
-		Connector: plan.Connector.ValueString(),
-		Config:    config,
+		Name:        plan.Name.ValueString(),
+		Connector:   plan.Connector.ValueString(),
+		Config:      config,
+		KcClusterId: plan.KcClusterId.ValueStringPointer(),
 	})
 
 	if err != nil {
@@ -280,6 +281,11 @@ func (r *SourceDynamoDBResource) Read(ctx context.Context, req res.ReadRequest, 
 	state.Name = types.StringValue(source.Name)
 	state.Connector = types.StringValue(source.Connector)
 	r.configMap2Model(source.Config, &state)
+	if source.KcClusterId != nil {
+		state.KcClusterId = types.StringValue(*source.KcClusterId)
+	} else {
+		state.KcClusterId = types.StringNull()
+	}
 	// Save updated data into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
@@ -300,9 +306,10 @@ func (r *SourceDynamoDBResource) Update(ctx context.Context, req res.UpdateReque
 	config := r.model2ConfigMap(plan)
 
 	source, err := r.client.UpdateSource(ctx, plan.ID.ValueString(), api.Source{
-		Name:      plan.Name.ValueString(),
-		Connector: plan.Connector.ValueString(),
-		Config:    config,
+		Name:        plan.Name.ValueString(),
+		Connector:   plan.Connector.ValueString(),
+		Config:      config,
+		KcClusterId: plan.KcClusterId.ValueStringPointer(),
 	})
 
 	if err != nil {
@@ -366,7 +373,6 @@ func (r *SourceDynamoDBResource) model2ConfigMap(model SourceDynamoDBResourceMod
 		"array.encoding.json":              model.ArrayEncodingJson.ValueBool(),
 		"struct.encoding.json":             model.StructEncodingJson.ValueBool(),
 		"tasks.max":                        model.TasksMax.ValueInt64(),
-		"kc.cluster.id":                    model.KcClusterId.ValueStringPointer(),
 	}
 }
 
@@ -387,5 +393,4 @@ func (r *SourceDynamoDBResource) configMap2Model(cfg map[string]any, model *Sour
 	model.ArrayEncodingJson = helper.GetTfCfgBool(cfg, "array.encoding.json")
 	model.StructEncodingJson = helper.GetTfCfgBool(cfg, "struct.encoding.json")
 	model.TasksMax = helper.GetTfCfgInt64(cfg, "tasks.max")
-	model.KcClusterId = helper.GetTfCfgString(cfg, "kc.cluster.id")
 }

--- a/internal/resource/source/kafkadirect.go
+++ b/internal/resource/source/kafkadirect.go
@@ -148,9 +148,10 @@ func (r *SourceKafkaDirectResource) Create(ctx context.Context, req res.CreateRe
 	config := r.model2ConfigMap(plan)
 
 	source, err := r.client.CreateSource(ctx, api.Source{
-		Name:      plan.Name.ValueString(),
-		Connector: plan.Connector.ValueString(),
-		Config:    config,
+		Name:        plan.Name.ValueString(),
+		Connector:   plan.Connector.ValueString(),
+		Config:      config,
+		KcClusterId: plan.KcClusterId.ValueStringPointer(),
 	})
 
 	if err != nil {
@@ -203,6 +204,11 @@ func (r *SourceKafkaDirectResource) Read(ctx context.Context, req res.ReadReques
 	state.Name = types.StringValue(source.Name)
 	state.Connector = types.StringValue(source.Connector)
 	r.configMap2Model(source.Config, &state)
+	if source.KcClusterId != nil {
+		state.KcClusterId = types.StringValue(*source.KcClusterId)
+	} else {
+		state.KcClusterId = types.StringNull()
+	}
 	// Save updated data into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
@@ -223,9 +229,10 @@ func (r *SourceKafkaDirectResource) Update(ctx context.Context, req res.UpdateRe
 	config := r.model2ConfigMap(plan)
 
 	source, err := r.client.UpdateSource(ctx, plan.ID.ValueString(), api.Source{
-		Name:      plan.Name.ValueString(),
-		Connector: plan.Connector.ValueString(),
-		Config:    config,
+		Name:        plan.Name.ValueString(),
+		Connector:   plan.Connector.ValueString(),
+		Config:      config,
+		KcClusterId: plan.KcClusterId.ValueStringPointer(),
 	})
 
 	if err != nil {
@@ -278,7 +285,6 @@ func (r *SourceKafkaDirectResource) model2ConfigMap(model SourceKafkaDirectResou
 		"format":                          model.KafkaFormat.ValueString(),
 		"topic.include.list.user.defined": model.TopicIncludeList.ValueString(),
 		"schemas.enable":                  model.SchemasEnable.ValueBool(),
-		"kc.cluster.id":                   model.KcClusterId.ValueStringPointer(),
 	}
 }
 
@@ -288,5 +294,4 @@ func (r *SourceKafkaDirectResource) configMap2Model(cfg map[string]any, model *S
 	model.KafkaFormat = helper.GetTfCfgString(cfg, "format")
 	model.TopicIncludeList = helper.GetTfCfgString(cfg, "topic.include.list.user.defined")
 	model.SchemasEnable = helper.GetTfCfgBool(cfg, "schemas.enable")
-	model.KcClusterId = helper.GetTfCfgString(cfg, "kc.cluster.id")
 }

--- a/internal/resource/source/kafkadirect.go
+++ b/internal/resource/source/kafkadirect.go
@@ -46,6 +46,7 @@ type SourceKafkaDirectResourceModel struct {
 	KafkaFormat      types.String `tfsdk:"kafka_format"`
 	SchemasEnable    types.Bool   `tfsdk:"schemas_enable"`
 	TopicIncludeList types.String `tfsdk:"topic_include_list"`
+	KcClusterId      types.String `tfsdk:"kc_cluster_id"`
 }
 
 func (r *SourceKafkaDirectResource) Metadata(ctx context.Context, req res.MetadataRequest, resp *res.MetadataResponse) {
@@ -106,6 +107,10 @@ func (r *SourceKafkaDirectResource) Schema(ctx context.Context, req res.SchemaRe
 				Required:            true,
 				Description:         "Topics to sync",
 				MarkdownDescription: "Topics to sync",
+			},
+			"kc_cluster_id": schema.StringAttribute{
+				Optional:    true,
+				Description: "KC cluster ID to deploy this connector to. Omit for default cluster.",
 			},
 		},
 	}
@@ -273,6 +278,7 @@ func (r *SourceKafkaDirectResource) model2ConfigMap(model SourceKafkaDirectResou
 		"format":                          model.KafkaFormat.ValueString(),
 		"topic.include.list.user.defined": model.TopicIncludeList.ValueString(),
 		"schemas.enable":                  model.SchemasEnable.ValueBool(),
+		"kc.cluster.id":                   model.KcClusterId.ValueStringPointer(),
 	}
 }
 
@@ -282,4 +288,5 @@ func (r *SourceKafkaDirectResource) configMap2Model(cfg map[string]any, model *S
 	model.KafkaFormat = helper.GetTfCfgString(cfg, "format")
 	model.TopicIncludeList = helper.GetTfCfgString(cfg, "topic.include.list.user.defined")
 	model.SchemasEnable = helper.GetTfCfgBool(cfg, "schemas.enable")
+	model.KcClusterId = helper.GetTfCfgString(cfg, "kc.cluster.id")
 }

--- a/internal/resource/source/mongodb.go
+++ b/internal/resource/source/mongodb.go
@@ -61,6 +61,7 @@ type SourceMongoDBResourceModel struct {
 	InsertStaticKeyValue2                   types.String `tfsdk:"insert_static_key_value_2"`
 	InsertStaticValueField2                 types.String `tfsdk:"insert_static_value_field_2"`
 	InsertStaticValue2                      types.String `tfsdk:"insert_static_value_2"`
+	KcClusterId                             types.String `tfsdk:"kc_cluster_id"`
 }
 
 func (r *SourceMongoDBResource) Metadata(ctx context.Context, req res.MetadataRequest, resp *res.MetadataResponse) {
@@ -226,6 +227,10 @@ func (r *SourceMongoDBResource) Schema(ctx context.Context, req res.SchemaReques
 				Default:             stringdefault.StaticString(""),
 				Description:         "The value of the static field to be added to the message value.",
 				MarkdownDescription: "The value of the static field to be added to the message value.",
+			},
+			"kc_cluster_id": schema.StringAttribute{
+				Optional:    true,
+				Description: "KC cluster ID to deploy this connector to. Omit for default cluster.",
 			},
 		},
 	}
@@ -408,6 +413,7 @@ func (r *SourceMongoDBResource) model2ConfigMap(model SourceMongoDBResourceModel
 		"transforms.InsertStaticKey2.static.value":      model.InsertStaticKeyValue2.ValueString(),
 		"transforms.InsertStaticValue2.static.field":    model.InsertStaticValueField2.ValueString(),
 		"transforms.InsertStaticValue2.static.value":    model.InsertStaticValue2.ValueString(),
+		"kc.cluster.id": model.KcClusterId.ValueStringPointer(),
 	}
 }
 
@@ -432,4 +438,5 @@ func (r *SourceMongoDBResource) configMap2Model(cfg map[string]any, model *Sourc
 	model.InsertStaticKeyValue2 = helper.GetTfCfgString(cfg, "transforms.InsertStaticKey2.static.value")
 	model.InsertStaticValueField2 = helper.GetTfCfgString(cfg, "transforms.InsertStaticValue2.static.field")
 	model.InsertStaticValue2 = helper.GetTfCfgString(cfg, "transforms.InsertStaticValue2.static.value")
+	model.KcClusterId = helper.GetTfCfgString(cfg, "kc.cluster.id")
 }

--- a/internal/resource/source/mongodb.go
+++ b/internal/resource/source/mongodb.go
@@ -268,9 +268,10 @@ func (r *SourceMongoDBResource) Create(ctx context.Context, req res.CreateReques
 	config := r.model2ConfigMap(plan)
 
 	source, err := r.client.CreateSource(ctx, api.Source{
-		Name:      plan.Name.ValueString(),
-		Connector: plan.Connector.ValueString(),
-		Config:    config,
+		Name:        plan.Name.ValueString(),
+		Connector:   plan.Connector.ValueString(),
+		Config:      config,
+		KcClusterId: plan.KcClusterId.ValueStringPointer(),
 	})
 
 	if err != nil {
@@ -323,6 +324,11 @@ func (r *SourceMongoDBResource) Read(ctx context.Context, req res.ReadRequest, r
 	state.Name = types.StringValue(source.Name)
 	state.Connector = types.StringValue(source.Connector)
 	r.configMap2Model(source.Config, &state)
+	if source.KcClusterId != nil {
+		state.KcClusterId = types.StringValue(*source.KcClusterId)
+	} else {
+		state.KcClusterId = types.StringNull()
+	}
 	// Save updated data into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
@@ -343,9 +349,10 @@ func (r *SourceMongoDBResource) Update(ctx context.Context, req res.UpdateReques
 	config := r.model2ConfigMap(plan)
 
 	source, err := r.client.UpdateSource(ctx, plan.ID.ValueString(), api.Source{
-		Name:      plan.Name.ValueString(),
-		Connector: plan.Connector.ValueString(),
-		Config:    config,
+		Name:        plan.Name.ValueString(),
+		Connector:   plan.Connector.ValueString(),
+		Config:      config,
+		KcClusterId: plan.KcClusterId.ValueStringPointer(),
 	})
 
 	if err != nil {
@@ -413,7 +420,6 @@ func (r *SourceMongoDBResource) model2ConfigMap(model SourceMongoDBResourceModel
 		"transforms.InsertStaticKey2.static.value":      model.InsertStaticKeyValue2.ValueString(),
 		"transforms.InsertStaticValue2.static.field":    model.InsertStaticValueField2.ValueString(),
 		"transforms.InsertStaticValue2.static.value":    model.InsertStaticValue2.ValueString(),
-		"kc.cluster.id": model.KcClusterId.ValueStringPointer(),
 	}
 }
 
@@ -438,5 +444,4 @@ func (r *SourceMongoDBResource) configMap2Model(cfg map[string]any, model *Sourc
 	model.InsertStaticKeyValue2 = helper.GetTfCfgString(cfg, "transforms.InsertStaticKey2.static.value")
 	model.InsertStaticValueField2 = helper.GetTfCfgString(cfg, "transforms.InsertStaticValue2.static.field")
 	model.InsertStaticValue2 = helper.GetTfCfgString(cfg, "transforms.InsertStaticValue2.static.value")
-	model.KcClusterId = helper.GetTfCfgString(cfg, "kc.cluster.id")
 }

--- a/internal/resource/source/mysql.go
+++ b/internal/resource/source/mysql.go
@@ -70,6 +70,7 @@ type SourceMySQLResourceModel struct {
 	SSHPort                                 types.String `tfsdk:"ssh_port"`
 	SSHUser                                 types.String `tfsdk:"ssh_user"`
 	PredicatesIsTopicToEnrichPattern        types.String `tfsdk:"predicates_istopictoenrich_pattern"`
+	KcClusterId                             types.String `tfsdk:"kc_cluster_id"`
 }
 
 func (r *SourceMySQLResource) Metadata(ctx context.Context, req res.MetadataRequest, resp *res.MetadataResponse) {
@@ -369,6 +370,10 @@ func (r *SourceMySQLResource) Schema(ctx context.Context, req res.SchemaRequest,
 				Description:         "Regex pattern to match topics for enrichment",
 				MarkdownDescription: "Regex pattern to match topics for enrichment",
 			},
+			"kc_cluster_id": schema.StringAttribute{
+				Optional:    true,
+				Description: "KC cluster ID to deploy this connector to. Omit for default cluster.",
+			},
 		},
 	}
 }
@@ -579,6 +584,7 @@ func (r *SourceMySQLResource) model2ConfigMap(model SourceMySQLResourceModel) (m
 		"ssh.port":                                     model.SSHPort.ValueString(),
 		"ssh.user":                                     model.SSHUser.ValueString(),
 		"predicates.IsTopicToEnrich.pattern":    model.PredicatesIsTopicToEnrichPattern.ValueString(),
+		"kc.cluster.id": model.KcClusterId.ValueStringPointer(),
 	}
 
 	if !model.ColumnIncludeList.IsNull() {
@@ -621,4 +627,5 @@ func (r *SourceMySQLResource) configMap2Model(cfg map[string]any, model *SourceM
 	model.SSHPort = helper.GetTfCfgString(cfg, "ssh.port")
 	model.SSHUser = helper.GetTfCfgString(cfg, "ssh.user")
 	model.PredicatesIsTopicToEnrichPattern = helper.GetTfCfgString(cfg, "predicates.IsTopicToEnrich.pattern")
+	model.KcClusterId = helper.GetTfCfgString(cfg, "kc.cluster.id")
 }

--- a/internal/resource/source/mysql.go
+++ b/internal/resource/source/mysql.go
@@ -417,9 +417,10 @@ func (r *SourceMySQLResource) Create(ctx context.Context, req res.CreateRequest,
 	}
 
 	source, err := r.client.CreateSource(ctx, api.Source{
-		Name:      plan.Name.ValueString(),
-		Connector: plan.Connector.ValueString(),
-		Config:    config,
+		Name:        plan.Name.ValueString(),
+		Connector:   plan.Connector.ValueString(),
+		Config:      config,
+		KcClusterId: plan.KcClusterId.ValueStringPointer(),
 	})
 
 	if err != nil {
@@ -472,6 +473,11 @@ func (r *SourceMySQLResource) Read(ctx context.Context, req res.ReadRequest, res
 	state.Name = types.StringValue(source.Name)
 	state.Connector = types.StringValue(source.Connector)
 	r.configMap2Model(source.Config, &state)
+	if source.KcClusterId != nil {
+		state.KcClusterId = types.StringValue(*source.KcClusterId)
+	} else {
+		state.KcClusterId = types.StringNull()
+	}
 	// Save updated data into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
@@ -499,9 +505,10 @@ func (r *SourceMySQLResource) Update(ctx context.Context, req res.UpdateRequest,
 	}
 
 	source, err := r.client.UpdateSource(ctx, plan.ID.ValueString(), api.Source{
-		Name:      plan.Name.ValueString(),
-		Connector: plan.Connector.ValueString(),
-		Config:    config,
+		Name:        plan.Name.ValueString(),
+		Connector:   plan.Connector.ValueString(),
+		Config:      config,
+		KcClusterId: plan.KcClusterId.ValueStringPointer(),
 	})
 
 	if err != nil {
@@ -584,7 +591,6 @@ func (r *SourceMySQLResource) model2ConfigMap(model SourceMySQLResourceModel) (m
 		"ssh.port":                                     model.SSHPort.ValueString(),
 		"ssh.user":                                     model.SSHUser.ValueString(),
 		"predicates.IsTopicToEnrich.pattern":    model.PredicatesIsTopicToEnrichPattern.ValueString(),
-		"kc.cluster.id": model.KcClusterId.ValueStringPointer(),
 	}
 
 	if !model.ColumnIncludeList.IsNull() {
@@ -627,5 +633,4 @@ func (r *SourceMySQLResource) configMap2Model(cfg map[string]any, model *SourceM
 	model.SSHPort = helper.GetTfCfgString(cfg, "ssh.port")
 	model.SSHUser = helper.GetTfCfgString(cfg, "ssh.user")
 	model.PredicatesIsTopicToEnrichPattern = helper.GetTfCfgString(cfg, "predicates.IsTopicToEnrich.pattern")
-	model.KcClusterId = helper.GetTfCfgString(cfg, "kc.cluster.id")
 }

--- a/internal/resource/source/postgresql.go
+++ b/internal/resource/source/postgresql.go
@@ -74,6 +74,7 @@ type SourcePostgreSQLResourceModel struct {
 	InsertStaticKeyValue2                   types.String `tfsdk:"insert_static_key_value_2"`
 	InsertStaticValueField2                 types.String `tfsdk:"insert_static_value_field_2"`
 	InsertStaticValue2                      types.String `tfsdk:"insert_static_value_2"`
+	KcClusterId                             types.String `tfsdk:"kc_cluster_id"`
 }
 
 func (r *SourcePostgreSQLResource) Metadata(ctx context.Context, req res.MetadataRequest, resp *res.MetadataResponse) {
@@ -330,6 +331,10 @@ func (r *SourcePostgreSQLResource) Schema(ctx context.Context, req res.SchemaReq
 				Description:         "The value of the static field to be added to the message value.",
 				MarkdownDescription: "The value of the static field to be added to the message value.",
 			},
+			"kc_cluster_id": schema.StringAttribute{
+				Optional:    true,
+				Description: "KC cluster ID to deploy this connector to. Omit for default cluster.",
+			},
 		},
 	}
 }
@@ -540,6 +545,7 @@ func (r *SourcePostgreSQLResource) model2ConfigMap(model SourcePostgreSQLResourc
 		"transforms.InsertStaticKey2.static.value":      model.InsertStaticKeyValue2.ValueString(),
 		"transforms.InsertStaticValue2.static.field":    model.InsertStaticValueField2.ValueString(),
 		"transforms.InsertStaticValue2.static.value":    model.InsertStaticValue2.ValueString(),
+		"kc.cluster.id": model.KcClusterId.ValueStringPointer(),
 	}
 
 	if !model.ColumnIncludeList.IsNull() {
@@ -586,4 +592,5 @@ func (r *SourcePostgreSQLResource) configMap2Model(cfg map[string]any, model *So
 	model.InsertStaticKeyValue2 = helper.GetTfCfgString(cfg, "transforms.InsertStaticKey2.static.value")
 	model.InsertStaticValueField2 = helper.GetTfCfgString(cfg, "transforms.InsertStaticValue2.static.field")
 	model.InsertStaticValue2 = helper.GetTfCfgString(cfg, "transforms.InsertStaticValue2.static.value")
+	model.KcClusterId = helper.GetTfCfgString(cfg, "kc.cluster.id")
 }

--- a/internal/resource/source/postgresql.go
+++ b/internal/resource/source/postgresql.go
@@ -378,9 +378,10 @@ func (r *SourcePostgreSQLResource) Create(ctx context.Context, req res.CreateReq
 	}
 
 	source, err := r.client.CreateSource(ctx, api.Source{
-		Name:      plan.Name.ValueString(),
-		Connector: plan.Connector.ValueString(),
-		Config:    config,
+		Name:        plan.Name.ValueString(),
+		Connector:   plan.Connector.ValueString(),
+		Config:      config,
+		KcClusterId: plan.KcClusterId.ValueStringPointer(),
 	})
 
 	if err != nil {
@@ -433,6 +434,11 @@ func (r *SourcePostgreSQLResource) Read(ctx context.Context, req res.ReadRequest
 	state.Name = types.StringValue(source.Name)
 	state.Connector = types.StringValue(source.Connector)
 	r.configMap2Model(source.Config, &state)
+	if source.KcClusterId != nil {
+		state.KcClusterId = types.StringValue(*source.KcClusterId)
+	} else {
+		state.KcClusterId = types.StringNull()
+	}
 	// Save updated data into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
@@ -460,9 +466,10 @@ func (r *SourcePostgreSQLResource) Update(ctx context.Context, req res.UpdateReq
 	}
 
 	source, err := r.client.UpdateSource(ctx, plan.ID.ValueString(), api.Source{
-		Name:      plan.Name.ValueString(),
-		Connector: plan.Connector.ValueString(),
-		Config:    config,
+		Name:        plan.Name.ValueString(),
+		Connector:   plan.Connector.ValueString(),
+		Config:      config,
+		KcClusterId: plan.KcClusterId.ValueStringPointer(),
 	})
 
 	if err != nil {
@@ -545,7 +552,6 @@ func (r *SourcePostgreSQLResource) model2ConfigMap(model SourcePostgreSQLResourc
 		"transforms.InsertStaticKey2.static.value":      model.InsertStaticKeyValue2.ValueString(),
 		"transforms.InsertStaticValue2.static.field":    model.InsertStaticValueField2.ValueString(),
 		"transforms.InsertStaticValue2.static.value":    model.InsertStaticValue2.ValueString(),
-		"kc.cluster.id": model.KcClusterId.ValueStringPointer(),
 	}
 
 	if !model.ColumnIncludeList.IsNull() {
@@ -592,5 +598,4 @@ func (r *SourcePostgreSQLResource) configMap2Model(cfg map[string]any, model *So
 	model.InsertStaticKeyValue2 = helper.GetTfCfgString(cfg, "transforms.InsertStaticKey2.static.value")
 	model.InsertStaticValueField2 = helper.GetTfCfgString(cfg, "transforms.InsertStaticValue2.static.field")
 	model.InsertStaticValue2 = helper.GetTfCfgString(cfg, "transforms.InsertStaticValue2.static.value")
-	model.KcClusterId = helper.GetTfCfgString(cfg, "kc.cluster.id")
 }

--- a/internal/resource/source/sqlserver.go
+++ b/internal/resource/source/sqlserver.go
@@ -68,6 +68,7 @@ type SourceSQLServerResourceModel struct {
 	SnapshotParallelism                     types.Int64 `tfsdk:"snapshot_parallelism"`
 	SnapshotLargeTableThreshold             types.Int64 `tfsdk:"snapshot_large_table_threshold"`
 	SnapshotCustomTableConfig               map[string]snapshotCustomTableConfigModel `tfsdk:"snapshot_custom_table_config"`
+	KcClusterId                             types.String `tfsdk:"kc_cluster_id"`
 }
 
 type snapshotCustomTableConfigModel struct {
@@ -267,6 +268,10 @@ func (r *SourceSQLServerResource) Schema(ctx context.Context, req res.SchemaRequ
 				},
 				Description:         "Explicitly set nb of parallel chunks for tables. Format: {\"db.Some_Tbl\": {\"chunks\": 5}}. This allows manual settings for parallelization when stats are outdated and estimated table size cannot be computed reliably",
 				MarkdownDescription: "Explicitly set nb of parallel chunks for tables. Format: {\"db.Some_Tbl\": {\"chunks\": 5}}. This allows manual settings for parallelization when stats are outdated and estimated table size cannot be computed reliably",
+			},
+			"kc_cluster_id": schema.StringAttribute{
+				Optional:    true,
+				Description: "KC cluster ID to deploy this connector to. Omit for default cluster.",
 			},
 		},
 	}
@@ -500,6 +505,7 @@ func (r *SourceSQLServerResource) model2ConfigMap(model SourceSQLServerResourceM
 		"streamkap.snapshot.parallelism":               model.SnapshotParallelism.ValueInt64(),
 		"streamkap.snapshot.large.table.threshold":     model.SnapshotLargeTableThreshold.ValueInt64(),
 		"streamkap.snapshot.custom.table.config.user.defined": expectedSnapshotCustomTableConfig,
+		"kc.cluster.id": model.KcClusterId.ValueStringPointer(),
 	}
 
 	return configMap, nil
@@ -558,5 +564,6 @@ func (r *SourceSQLServerResource) configMap2Model(cfg map[string]any, model *Sou
 		}
 	}
 	model.SnapshotCustomTableConfig = snapshotCustomTableConfig
+	model.KcClusterId = helper.GetTfCfgString(cfg, "kc.cluster.id")
 	return
 }

--- a/internal/resource/source/sqlserver.go
+++ b/internal/resource/source/sqlserver.go
@@ -316,9 +316,10 @@ func (r *SourceSQLServerResource) Create(ctx context.Context, req res.CreateRequ
 	}
 
 	source, err := r.client.CreateSource(ctx, api.Source{
-		Name:      plan.Name.ValueString(),
-		Connector: plan.Connector.ValueString(),
-		Config:    config,
+		Name:        plan.Name.ValueString(),
+		Connector:   plan.Connector.ValueString(),
+		Config:      config,
+		KcClusterId: plan.KcClusterId.ValueStringPointer(),
 	})
 
 
@@ -372,6 +373,11 @@ func (r *SourceSQLServerResource) Read(ctx context.Context, req res.ReadRequest,
 	state.Name = types.StringValue(source.Name)
 	state.Connector = types.StringValue(source.Connector)
 	r.configMap2Model(source.Config, &state)
+	if source.KcClusterId != nil {
+		state.KcClusterId = types.StringValue(*source.KcClusterId)
+	} else {
+		state.KcClusterId = types.StringNull()
+	}
 	// Save updated data into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
@@ -399,9 +405,10 @@ func (r *SourceSQLServerResource) Update(ctx context.Context, req res.UpdateRequ
 	}
 
 	source, err := r.client.UpdateSource(ctx, plan.ID.ValueString(), api.Source{
-		Name:      plan.Name.ValueString(),
-		Connector: plan.Connector.ValueString(),
-		Config:    config,
+		Name:        plan.Name.ValueString(),
+		Connector:   plan.Connector.ValueString(),
+		Config:      config,
+		KcClusterId: plan.KcClusterId.ValueStringPointer(),
 	})
 
 	if err != nil {
@@ -505,7 +512,6 @@ func (r *SourceSQLServerResource) model2ConfigMap(model SourceSQLServerResourceM
 		"streamkap.snapshot.parallelism":               model.SnapshotParallelism.ValueInt64(),
 		"streamkap.snapshot.large.table.threshold":     model.SnapshotLargeTableThreshold.ValueInt64(),
 		"streamkap.snapshot.custom.table.config.user.defined": expectedSnapshotCustomTableConfig,
-		"kc.cluster.id": model.KcClusterId.ValueStringPointer(),
 	}
 
 	return configMap, nil
@@ -564,6 +570,5 @@ func (r *SourceSQLServerResource) configMap2Model(cfg map[string]any, model *Sou
 		}
 	}
 	model.SnapshotCustomTableConfig = snapshotCustomTableConfig
-	model.KcClusterId = helper.GetTfCfgString(cfg, "kc.cluster.id")
 	return
 }

--- a/internal/resource/transform/topic_router.go
+++ b/internal/resource/transform/topic_router.go
@@ -1,0 +1,275 @@
+package transform
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	res "github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+
+	"github.com/streamkap-com/terraform-provider-streamkap/internal/api"
+	"github.com/streamkap-com/terraform-provider-streamkap/internal/helper"
+)
+
+// Ensure provider defined types fully satisfy framework interfaces.
+var (
+	_ res.Resource                = &TransformTopicRouterResource{}
+	_ res.ResourceWithConfigure   = &TransformTopicRouterResource{}
+	_ res.ResourceWithImportState = &TransformTopicRouterResource{}
+)
+
+func NewTransformTopicRouterResource() res.Resource {
+	return &TransformTopicRouterResource{}
+}
+
+// TransformTopicRouterResource defines the resource implementation.
+type TransformTopicRouterResource struct {
+	client api.StreamkapAPI
+}
+
+// TransformTopicRouterResourceModel describes the resource data model.
+type TransformTopicRouterResourceModel struct {
+	ID              types.String `tfsdk:"id"`
+	Name            types.String `tfsdk:"name"`
+	TopicPrefix     types.String `tfsdk:"topic_prefix"`
+	InputTopicIDs   types.String `tfsdk:"input_topic_ids"`
+	KcClusterId     types.String `tfsdk:"kc_cluster_id"`
+	TransformType   types.String `tfsdk:"transform_type"`
+}
+
+func (r *TransformTopicRouterResource) Metadata(ctx context.Context, req res.MetadataRequest, resp *res.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_transform_topic_router"
+}
+
+func (r *TransformTopicRouterResource) Schema(ctx context.Context, req res.SchemaRequest, resp *res.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description:         "Transform Topic Router resource — merges topics via KC connector with byte passthrough",
+		MarkdownDescription: "Transform Topic Router resource — merges topics via KC Kafka destination connector with byte passthrough (no value deserialization).",
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Computed:            true,
+				Description:         "Transform identifier",
+				MarkdownDescription: "Transform identifier",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"name": schema.StringAttribute{
+				Required:            true,
+				Description:         "Transform name",
+				MarkdownDescription: "Transform name",
+			},
+			"topic_prefix": schema.StringAttribute{
+				Required:            true,
+				Description:         "Output topic prefix for merged topics (e.g. 'merged.dbo.')",
+				MarkdownDescription: "Output topic prefix for merged topics (e.g. `merged.dbo.`)",
+			},
+			"input_topic_ids": schema.StringAttribute{
+				Required:            true,
+				Description:         "Comma-separated list of input topic IDs to merge",
+				MarkdownDescription: "Comma-separated list of input topic IDs to merge",
+			},
+			"kc_cluster_id": schema.StringAttribute{
+				Optional:            true,
+				Computed:            true,
+				Default:             stringdefault.StaticString(""),
+				Description:         "KC cluster ID to deploy the connector to",
+				MarkdownDescription: "KC cluster ID to deploy the connector to. Empty for default cluster.",
+			},
+			"transform_type": schema.StringAttribute{
+				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+		},
+	}
+}
+
+func (r *TransformTopicRouterResource) Configure(ctx context.Context, req res.ConfigureRequest, resp *res.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	client, ok := req.ProviderData.(api.StreamkapAPI)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Transform Topic Router Configure Type",
+			fmt.Sprintf("Expected api.StreamkapAPI, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+		return
+	}
+	r.client = client
+}
+
+func (r *TransformTopicRouterResource) Create(ctx context.Context, req res.CreateRequest, resp *res.CreateResponse) {
+	var plan TransformTopicRouterResourceModel
+
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	tflog.Debug(ctx, "Pre CREATE topic_router ===> plan: "+fmt.Sprintf("%+v", plan))
+
+	transform, err := r.client.CreateTransform(ctx, api.Transform{
+		Name:          plan.Name.ValueString(),
+		TransformType: "topic_router",
+		Config: map[string]any{
+			"transforms.name":                      plan.Name.ValueString(),
+			"transforms.input.topic.pattern":        plan.InputTopicIDs.ValueString(),
+			"transforms.output.topic.pattern":       "",
+			"transforms.input.serialization.format":  "Any",
+			"transforms.output.serialization.format": "Any",
+		},
+		Implementation: map[string]any{
+			"topic_prefix":  plan.TopicPrefix.ValueString(),
+			"kc_cluster_id": plan.KcClusterId.ValueString(),
+		},
+	})
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error creating topic_router transform",
+			fmt.Sprintf("Unable to create topic_router transform, got error: %s", err),
+		)
+		return
+	}
+
+	plan.ID = types.StringValue(transform.ID)
+	plan.TransformType = types.StringValue(transform.TransformType)
+
+	// Deploy live immediately after creation
+	err = r.client.DeployTransformLive(ctx, transform.ID, "0")
+	if err != nil {
+		resp.Diagnostics.AddWarning(
+			"Transform created but deploy failed",
+			fmt.Sprintf("Transform %s was created but live deployment failed: %s. You may need to deploy manually.", transform.ID, err),
+		)
+	}
+
+	tflog.Debug(ctx, "Post CREATE topic_router ===> plan: "+fmt.Sprintf("%+v", plan))
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
+}
+
+func (r *TransformTopicRouterResource) Read(ctx context.Context, req res.ReadRequest, resp *res.ReadResponse) {
+	var state TransformTopicRouterResourceModel
+
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	transformID := state.ID.ValueString()
+	transform, err := r.client.GetTransform(ctx, transformID)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error reading topic_router transform",
+			fmt.Sprintf("Unable to read topic_router transform, got error: %s", err),
+		)
+		return
+	}
+	if transform == nil {
+		resp.Diagnostics.AddError(
+			"Error reading topic_router transform",
+			fmt.Sprintf("Topic router transform %s does not exist", transformID),
+		)
+		return
+	}
+
+	state.Name = types.StringValue(transform.Name)
+	state.TransformType = types.StringValue(transform.TransformType)
+
+	// Read implementation fields
+	if transform.Implementation != nil {
+		if v, ok := transform.Implementation["topic_prefix"]; ok && v != nil {
+			state.TopicPrefix = helper.GetTfCfgString(transform.Implementation, "topic_prefix")
+		}
+		if v, ok := transform.Implementation["kc_cluster_id"]; ok && v != nil {
+			state.KcClusterId = helper.GetTfCfgString(transform.Implementation, "kc_cluster_id")
+		}
+	}
+
+	// Read input topic pattern from config
+	if transform.Config != nil {
+		state.InputTopicIDs = helper.GetTfCfgString(transform.Config, "transforms.input.topic.pattern")
+	}
+
+	tflog.Info(ctx, "===> topic_router state: "+fmt.Sprintf("%+v", state))
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+func (r *TransformTopicRouterResource) Update(ctx context.Context, req res.UpdateRequest, resp *res.UpdateResponse) {
+	var plan TransformTopicRouterResourceModel
+
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	transform, err := r.client.UpdateTransform(ctx, plan.ID.ValueString(), api.Transform{
+		Name:          plan.Name.ValueString(),
+		TransformType: "topic_router",
+		Config: map[string]any{
+			"transforms.name":                      plan.Name.ValueString(),
+			"transforms.input.topic.pattern":        plan.InputTopicIDs.ValueString(),
+			"transforms.output.topic.pattern":       "",
+			"transforms.input.serialization.format":  "Any",
+			"transforms.output.serialization.format": "Any",
+		},
+		Implementation: map[string]any{
+			"topic_prefix":  plan.TopicPrefix.ValueString(),
+			"kc_cluster_id": plan.KcClusterId.ValueString(),
+		},
+	})
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error updating topic_router transform",
+			fmt.Sprintf("Unable to update topic_router transform, got error: %s", err),
+		)
+		return
+	}
+
+	plan.Name = types.StringValue(transform.Name)
+	plan.TransformType = types.StringValue(transform.TransformType)
+
+	// Re-deploy after update
+	err = r.client.DeployTransformLive(ctx, plan.ID.ValueString(), "0")
+	if err != nil {
+		resp.Diagnostics.AddWarning(
+			"Transform updated but deploy failed",
+			fmt.Sprintf("Transform %s was updated but live deployment failed: %s. You may need to deploy manually.", plan.ID.ValueString(), err),
+		)
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+func (r *TransformTopicRouterResource) Delete(ctx context.Context, req res.DeleteRequest, resp *res.DeleteResponse) {
+	var state TransformTopicRouterResourceModel
+
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	err := r.client.DeleteTransform(ctx, state.ID.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error deleting topic_router transform",
+			fmt.Sprintf("Unable to delete topic_router transform, got error: %s", err),
+		)
+		return
+	}
+}
+
+func (r *TransformTopicRouterResource) ImportState(ctx context.Context, req res.ImportStateRequest, resp *res.ImportStateResponse) {
+	res.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}


### PR DESCRIPTION
## Workorder: STR-4371-kc-api-and-terraform-timeouts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Transform "topic router" resource and related transform lifecycle operations (create/update/delete/deploy).
  * Kafka destinations: configurable offset field and original-topic preservation (off/header/field).
  * Added optional "KC cluster ID" field across many source and destination connectors.

* **Bug Fixes**
  * Create, update, and delete operations for sources/destinations are now non-blocking (requests return immediately).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->