### PR TITLE
fix: resolve issue #75 and harden transform resource

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,25 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## Public Repository — Content Hygiene
+
+**This repository is public.** Everything committed — code, comments, commit messages, PR descriptions, test fixtures, documentation — is visible to the world. Be deliberate about what goes in.
+
+Do **not** write any of the following into files, commits, or PRs:
+- Internal ticket IDs or internal URLs (Jira/Linear, internal wikis, Slack links, internal dashboards)
+- Customer names, tenant IDs, service IDs, email addresses, real credentials, or API tokens
+- Internal hostnames, staging URLs, or private infrastructure details
+- Verbatim error traces from production or private log snippets
+- Internal-only roadmap details, unannounced features, or internal team names
+
+When you need to reference something for context:
+- Public GitHub issue numbers (e.g. `#75`) are fine — they live in this repo.
+- Prefer the public `https://api.streamkap.com` and `https://docs.streamkap.com` surfaces.
+- Strip ticket prefixes from commit messages and code comments unless they're already public.
+- If you find existing internal references during other work, flag them — a previous commit (`chore: scrub internal references for public repo hygiene`) did one sweep, but drift happens.
+
+If you're unsure whether something is safe to commit, ask before writing it.
+
 ## Overview
 
 Terraform provider for Streamkap (data streaming platform). Built with Terraform Plugin Framework (Go 1.24+). Provider address: `github.com/streamkap-com/streamkap`

--- a/internal/api/transform.go
+++ b/internal/api/transform.go
@@ -77,24 +77,29 @@ func (s *streamkapAPI) GetTransform(ctx context.Context, TransformID string) (*T
 }
 
 func (s *streamkapAPI) ListTransforms(ctx context.Context) ([]Transform, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, s.cfg.BaseURL+"/transforms?secret_returned=true", http.NoBody)
-	if err != nil {
-		return nil, err
+	// Backend default page_size is 10 (max 100). Iterate until we have all
+	// results so callers (sweepers, adopt fallbacks) see the full tenant, not
+	// just page 1. See ListSources for the equivalent pattern.
+	const pageSize = 100
+	const maxPages = 1000
+	var all []Transform
+	for page := 1; page <= maxPages; page++ {
+		reqURL := fmt.Sprintf("%s/transforms?secret_returned=true&page=%d&page_size=%d", s.cfg.BaseURL, page, pageSize)
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, http.NoBody)
+		if err != nil {
+			return nil, err
+		}
+		tflog.Debug(ctx, fmt.Sprintf("ListTransforms request details:\n\tMethod: %s\n\tURL: %s\n", req.Method, req.URL.String()))
+		var resp GetTransformResponse
+		if err := s.doRequest(ctx, req, &resp); err != nil {
+			return nil, err
+		}
+		all = append(all, resp.Result...)
+		if len(resp.Result) < pageSize {
+			break
+		}
 	}
-	tflog.Debug(ctx, fmt.Sprintf(
-		"ListTransforms request details:\n"+
-			"\tMethod: %s\n"+
-			"\tURL: %s\n",
-		req.Method,
-		req.URL.String(),
-	))
-	var resp GetTransformResponse
-	err = s.doRequest(ctx, req, &resp)
-	if err != nil {
-		return nil, err
-	}
-
-	return resp.Result, nil
+	return all, nil
 }
 
 func (s *streamkapAPI) CreateTransform(ctx context.Context, reqPayload CreateTransformRequest) (*Transform, error) {
@@ -123,10 +128,18 @@ func (s *streamkapAPI) CreateTransform(ctx context.Context, reqPayload CreateTra
 	err = s.doRequestWithRetry(ctx, req, &resp)
 	if err != nil {
 		if strings.Contains(err.Error(), "already exists") {
-			name, _ := reqPayload.Config["name"].(string)
+			// The transform name lives inside the config map under the
+			// backend's alias "transforms.name" (see base.go Create), not at
+			// the top level like sources/destinations.
+			name, _ := reqPayload.Config["transforms.name"].(string)
 			tflog.Info(ctx, fmt.Sprintf(
-				"Transform %q already exists — adopting existing resource", name))
-			return s.adoptTransformByName(ctx, name)
+				"Transform %q already exists — attempting to adopt existing resource", name))
+			adopted, adoptErr := s.adoptTransformByName(ctx, name)
+			if adoptErr == nil {
+				return adopted, nil
+			}
+			// See matching comment in source.go CreateSource.
+			return nil, fmt.Errorf("%w (also tried to adopt the existing resource but could not locate it via the list endpoint: %v)", err, adoptErr)
 		}
 		return nil, err
 	}
@@ -134,16 +147,29 @@ func (s *streamkapAPI) CreateTransform(ctx context.Context, reqPayload CreateTra
 	return &resp, nil
 }
 
-// adoptTransformByName finds an existing transform by name and returns it,
-// allowing Terraform to adopt it into state after a 409 conflict.
+// adoptTransformByName — see adoptSourceByName for rationale (paginates
+// through all partial_name matches to find the exact-name transform).
 func (s *streamkapAPI) adoptTransformByName(ctx context.Context, name string) (*Transform, error) {
-	transforms, err := s.ListTransforms(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("failed to list transforms while adopting %q: %w", name, err)
-	}
-	for i := range transforms {
-		if transforms[i].Name == name {
-			return &transforms[i], nil
+	const pageSize = 100
+	const maxPages = 1000
+	for page := 1; page <= maxPages; page++ {
+		reqURL := fmt.Sprintf("%s/transforms?secret_returned=true&page=%d&page_size=%d&partial_name=%s",
+			s.cfg.BaseURL, page, pageSize, url.QueryEscape(name))
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, http.NoBody)
+		if err != nil {
+			return nil, fmt.Errorf("failed to build adopt request for %q: %w", name, err)
+		}
+		var resp GetTransformResponse
+		if err := s.doRequest(ctx, req, &resp); err != nil {
+			return nil, fmt.Errorf("failed to list transforms while adopting %q: %w", name, err)
+		}
+		for i := range resp.Result {
+			if resp.Result[i].Name == name {
+				return &resp.Result[i], nil
+			}
+		}
+		if len(resp.Result) < pageSize {
+			break
 		}
 	}
 	return nil, fmt.Errorf("transform %q reported as existing but not found in list", name)

--- a/internal/datasource/transform.go
+++ b/internal/datasource/transform.go
@@ -160,11 +160,20 @@ func (r *TransformDataSource) modelFromAPIObject(apiObject api.Transform, model 
 	}
 	model.TopicIDs = topicIDs
 
+	// The API returns topic_ids and topics as two parallel slices, but they
+	// are not guaranteed to be the same length (e.g., a transform whose output
+	// topics are not yet resolved can return ids without names). Iterate by
+	// index and fall back to a null name when there is no paired entry to
+	// avoid a runtime panic.
 	topicMap := []TopicModel{}
 	for i, topicID := range apiObject.TopicIDs {
+		name := types.StringNull()
+		if i < len(apiObject.Topics) {
+			name = types.StringValue(apiObject.Topics[i])
+		}
 		topicMap = append(topicMap, TopicModel{
 			ID:   types.StringValue(topicID),
-			Name: types.StringValue(apiObject.Topics[i]),
+			Name: name,
 		})
 	}
 	model.TopicMap = topicMap

--- a/internal/datasource/transform_test.go
+++ b/internal/datasource/transform_test.go
@@ -1,0 +1,74 @@
+package datasource
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/streamkap-com/terraform-provider-streamkap/internal/api"
+)
+
+// TestModelFromAPIObject_MismatchedTopicsAndIDs is a regression test for a
+// runtime panic: the API returns topic_ids and topics as two parallel slices,
+// but they can legitimately differ in length (e.g., topics not yet resolved).
+// Previously topicMap[i].Name = apiObject.Topics[i] panicked when
+// len(Topics) < len(TopicIDs).
+func TestModelFromAPIObject_MismatchedTopicsAndIDs(t *testing.T) {
+	ds := &TransformDataSource{}
+
+	t.Run("fewer topics than ids", func(t *testing.T) {
+		apiObject := api.Transform{
+			ID:       "t-1",
+			Name:     "example",
+			TopicIDs: []string{"id-1", "id-2", "id-3"},
+			Topics:   []string{"topic-a"}, // only one name resolved
+		}
+		model := &TransformDataSourceModel{}
+
+		require.NotPanics(t, func() {
+			ds.modelFromAPIObject(apiObject, model)
+		})
+
+		require.Len(t, model.TopicMap, 3)
+		assert.Equal(t, "id-1", model.TopicMap[0].ID.ValueString())
+		assert.Equal(t, "topic-a", model.TopicMap[0].Name.ValueString())
+		assert.Equal(t, "id-2", model.TopicMap[1].ID.ValueString())
+		assert.True(t, model.TopicMap[1].Name.IsNull(), "unpaired id should yield null name")
+		assert.True(t, model.TopicMap[2].Name.IsNull())
+	})
+
+	t.Run("empty topics with populated ids", func(t *testing.T) {
+		apiObject := api.Transform{
+			ID:       "t-2",
+			Name:     "example",
+			TopicIDs: []string{"id-1"},
+			Topics:   nil,
+		}
+		model := &TransformDataSourceModel{}
+
+		require.NotPanics(t, func() {
+			ds.modelFromAPIObject(apiObject, model)
+		})
+
+		require.Len(t, model.TopicMap, 1)
+		assert.Equal(t, "id-1", model.TopicMap[0].ID.ValueString())
+		assert.True(t, model.TopicMap[0].Name.IsNull())
+	})
+
+	t.Run("matching lengths behave unchanged", func(t *testing.T) {
+		apiObject := api.Transform{
+			ID:       "t-3",
+			Name:     "example",
+			TopicIDs: []string{"id-1", "id-2"},
+			Topics:   []string{"topic-a", "topic-b"},
+		}
+		model := &TransformDataSourceModel{}
+
+		ds.modelFromAPIObject(apiObject, model)
+
+		require.Len(t, model.TopicMap, 2)
+		assert.Equal(t, "topic-a", model.TopicMap[0].Name.ValueString())
+		assert.Equal(t, "topic-b", model.TopicMap[1].Name.ValueString())
+	})
+}

--- a/internal/provider/error_handling_test.go
+++ b/internal/provider/error_handling_test.go
@@ -4,6 +4,7 @@ package provider
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
 	"testing"
 
@@ -778,6 +779,161 @@ func TestAPIError422_DuplicateName(t *testing.T) {
 	require.NotNil(t, result, "Adopted source should be returned")
 	assert.Equal(t, "adopted-source-id", result.ID, "Should return the existing source's ID")
 	assert.Equal(t, "existing-source", result.Name)
+}
+
+// TestListTransforms_Paginates exercises the paginated iteration in
+// ListTransforms so callers (sweepers, adopt fallbacks) see the full tenant,
+// not just page 1. The backend defaults to page_size=10; the client must
+// request page_size=100 and keep paging until a short page is returned.
+func TestListTransforms_Paginates(t *testing.T) {
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	baseURL := "https://api.test.streamkap.com"
+	client := newTestAPIClient(baseURL)
+
+	// Page 1: 100 results (a full page) → client must request page 2.
+	page1 := make([]api.Transform, 100)
+	for i := range page1 {
+		page1[i] = api.Transform{ID: fmt.Sprintf("t-page1-%d", i), Name: fmt.Sprintf("transform-%d", i), TransformType: "map_filter"}
+	}
+	// Page 2: 5 results (short page) → client stops here.
+	page2 := []api.Transform{
+		{ID: "t-page2-0", Name: "transform-100", TransformType: "map_filter"},
+		{ID: "t-page2-1", Name: "transform-101", TransformType: "map_filter"},
+		{ID: "t-page2-2", Name: "transform-102", TransformType: "map_filter"},
+		{ID: "t-page2-3", Name: "transform-103", TransformType: "map_filter"},
+		{ID: "t-page2-4", Name: "transform-104", TransformType: "map_filter"},
+	}
+
+	httpmock.RegisterResponder(
+		http.MethodGet,
+		baseURL+"/transforms?secret_returned=true&page=1&page_size=100",
+		httpmock.NewJsonResponderOrPanic(http.StatusOK, api.GetTransformResponse{
+			Total: 105, PageSize: 100, Page: 1, Result: page1,
+		}),
+	)
+	httpmock.RegisterResponder(
+		http.MethodGet,
+		baseURL+"/transforms?secret_returned=true&page=2&page_size=100",
+		httpmock.NewJsonResponderOrPanic(http.StatusOK, api.GetTransformResponse{
+			Total: 105, PageSize: 100, Page: 2, Result: page2,
+		}),
+	)
+
+	ctx := context.Background()
+	result, err := client.ListTransforms(ctx)
+
+	require.NoError(t, err)
+	assert.Len(t, result, 105, "all 105 transforms across both pages must be returned")
+	assert.Equal(t, "t-page1-0", result[0].ID)
+	assert.Equal(t, "t-page2-4", result[104].ID)
+}
+
+// TestAPIError422_TransformDuplicateName is a regression test for issue #75:
+// when a transform with the same name already exists, the create path must
+// adopt it. The transform name lives in Config["transforms.name"] (backend
+// alias), not Config["name"], so the adopt lookup previously searched for an
+// empty string and surfaced "transform \"\" reported as existing but not
+// found in list".
+func TestAPIError422_TransformDuplicateName(t *testing.T) {
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	baseURL := "https://api.test.streamkap.com"
+	client := newTestAPIClient(baseURL)
+
+	transform := api.CreateTransformRequest{
+		Transform: "sql_join",
+		Config: map[string]any{
+			"transforms.name":     "existing-transform",
+			"transforms.language": "SQL",
+		},
+	}
+
+	httpmock.RegisterResponder(
+		http.MethodPost,
+		baseURL+"/transforms?secret_returned=true",
+		func(req *http.Request) (*http.Response, error) {
+			errResponse := api.APIErrorResponse{
+				Detail: "A transform with name 'existing-transform' already exists",
+			}
+			return httpmock.NewJsonResponse(http.StatusUnprocessableEntity, errResponse)
+		},
+	)
+
+	// Mock the paginated partial_name-filtered list-for-adopt follow-up.
+	httpmock.RegisterResponder(
+		http.MethodGet,
+		baseURL+"/transforms?secret_returned=true&page=1&page_size=100&partial_name=existing-transform",
+		func(req *http.Request) (*http.Response, error) {
+			return httpmock.NewJsonResponse(http.StatusOK, api.GetTransformResponse{
+				Total: 1,
+				Result: []api.Transform{
+					{ID: "adopted-transform-id", Name: "existing-transform", TransformType: "sql_join"},
+				},
+			})
+		},
+	)
+
+	ctx := context.Background()
+	result, err := client.CreateTransform(ctx, transform)
+
+	require.NoError(t, err, "Duplicate name should trigger adoption, not an error")
+	require.NotNil(t, result, "Adopted transform should be returned")
+	assert.Equal(t, "adopted-transform-id", result.ID, "Should return the existing transform's ID")
+	assert.Equal(t, "existing-transform", result.Name)
+}
+
+// TestAPIError422_TransformDuplicateName_AdoptNotFound covers the path where
+// the backend reports "already exists" but the list endpoint can't locate the
+// transform (e.g. orphan in a different service of the same tenant). The
+// original error must be preserved so the user sees something actionable.
+func TestAPIError422_TransformDuplicateName_AdoptNotFound(t *testing.T) {
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	baseURL := "https://api.test.streamkap.com"
+	client := newTestAPIClient(baseURL)
+
+	transform := api.CreateTransformRequest{
+		Transform: "sql_join",
+		Config: map[string]any{
+			"transforms.name":     "orphan-transform",
+			"transforms.language": "SQL",
+		},
+	}
+
+	httpmock.RegisterResponder(
+		http.MethodPost,
+		baseURL+"/transforms?secret_returned=true",
+		func(req *http.Request) (*http.Response, error) {
+			errResponse := api.APIErrorResponse{
+				Detail: "A transform with name 'orphan-transform' already exists",
+			}
+			return httpmock.NewJsonResponse(http.StatusUnprocessableEntity, errResponse)
+		},
+	)
+
+	// List endpoint returns zero results — the adopt lookup cannot locate it.
+	httpmock.RegisterResponder(
+		http.MethodGet,
+		baseURL+"/transforms?secret_returned=true&page=1&page_size=100&partial_name=orphan-transform",
+		func(req *http.Request) (*http.Response, error) {
+			return httpmock.NewJsonResponse(http.StatusOK, api.GetTransformResponse{
+				Total:  0,
+				Result: []api.Transform{},
+			})
+		},
+	)
+
+	ctx := context.Background()
+	result, err := client.CreateTransform(ctx, transform)
+
+	require.Error(t, err, "Expected error when adopt lookup fails")
+	assert.Nil(t, result, "Result should be nil when adopt fails")
+	assert.Contains(t, err.Error(), "already exists", "Original error must be preserved")
+	assert.Contains(t, err.Error(), "could not locate it via the list endpoint", "Should explain the adopt failure")
 }
 
 // TestAPIError422_TransformInvalidConfig tests 422 for transform-specific validation

--- a/internal/resource/transform/base.go
+++ b/internal/resource/transform/base.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
@@ -390,19 +391,74 @@ func (r *BaseTransformResource) Read(ctx context.Context, req resource.ReadReque
 		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("implementation_json"), jsontypes.NewNormalizedNull())...)
 	}
 
-	// Read connector_status — only call API if transform was previously deployed
+	// Read connector_status.
+	//
+	// Three incoming cases via req.State.connector_status:
+	//   - null           → import path (no prior state). Must call the API or
+	//                      the imported resource will show UNKNOWN even when
+	//                      the transform is RUNNING, causing a spurious diff
+	//                      on the first post-import plan.
+	//   - "UNKNOWN"      → never deployed or deploy skipped. Skip the API
+	//                      call (cheap refresh for the common case).
+	//   - known non-null → refresh from the API; on API error, preserve the
+	//                      prior value rather than silently demoting to
+	//                      UNKNOWN, so a transient 5xx or network blip does
+	//                      not rewrite a confirmed RUNNING transform in
+	//                      state (users rely on this field for automation
+	//                      gates).
+	//
+	// The backend's /job_status endpoint rewrites HTTPException(404) into 400
+	// through a broad except-clause (see app/api/transforms_api.py::
+	// get_jobs_status), so we cannot rely on the HTTP status to tell
+	// "transform truly not deployed" apart from "transient failure".
+	// We fall back to matching the detail string: "Job not found" /
+	// "Transform not found" are authoritative "not deployed" signals and
+	// should demote prior state to UNKNOWN. Any other error is treated as
+	// transient — preserve the prior value so a 5xx or network blip does
+	// not silently rewrite a confirmed RUNNING transform in state.
 	var currentStatus types.String
 	resp.Diagnostics.Append(req.State.GetAttribute(ctx, path.Root("connector_status"), &currentStatus)...)
-	if !currentStatus.IsNull() && currentStatus.ValueString() != constants.JobStatusUnknown {
-		status, err := r.client.GetTransformJobStatus(ctx, id)
-		if err == nil && status != nil {
-			resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("connector_status"), types.StringValue(status.Status))...)
-		} else {
-			resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("connector_status"), types.StringValue(constants.JobStatusUnknown))...)
+
+	priorKnown := !currentStatus.IsNull() && currentStatus.ValueString() != constants.JobStatusUnknown
+	shouldRefresh := currentStatus.IsNull() || priorKnown
+
+	if !shouldRefresh {
+		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("connector_status"), types.StringValue(constants.JobStatusUnknown))...)
+		return
+	}
+
+	status, err := r.client.GetTransformJobStatus(ctx, id)
+	switch {
+	case err == nil && status != nil:
+		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("connector_status"), types.StringValue(status.Status))...)
+	case err != nil && isJobNotDeployedError(err):
+		// Authoritative "no deployment exists" — demote prior state so the
+		// Terraform plan surfaces the drift on the next apply.
+		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("connector_status"), types.StringValue(constants.JobStatusUnknown))...)
+	case priorKnown:
+		tflog.Warn(ctx, fmt.Sprintf("Failed to refresh job status for transform %s; preserving prior value %q: %v", id, currentStatus.ValueString(), err))
+		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("connector_status"), currentStatus)...)
+	default:
+		// Import path (currentStatus was null) and the API call failed —
+		// fall back to UNKNOWN so the attribute is populated.
+		if err != nil {
+			tflog.Warn(ctx, fmt.Sprintf("Failed to read job status on import for transform %s; defaulting to UNKNOWN: %v", id, err))
 		}
-	} else {
 		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("connector_status"), types.StringValue(constants.JobStatusUnknown))...)
 	}
+}
+
+// isJobNotDeployedError returns true when the backend's /job_status response
+// means "no deployment exists" as opposed to a transient failure. The backend
+// rewrites its 404 into a 400 via a broad except-clause, so we match on the
+// detail string the handler emits for both transform-level and job-level
+// misses (see app/api/transforms_api.py::get_jobs_status).
+func isJobNotDeployedError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "Job not found") || strings.Contains(msg, "Transform not found")
 }
 
 // Update updates the transform resource.

--- a/internal/resource/transform/base_test.go
+++ b/internal/resource/transform/base_test.go
@@ -1,8 +1,40 @@
 package transform
 
 import (
+	"errors"
 	"testing"
 )
+
+// TestIsJobNotDeployedError validates the string match that distinguishes
+// an authoritative "no deployment exists" signal from a transient backend
+// failure. The backend's /job_status handler rewrites HTTPException(404) into
+// 400 with either "Job not found" or "Transform not found" — those two detail
+// strings are the only signals we can rely on to demote connector_status to
+// UNKNOWN without letting transient 5xx errors silently lose state.
+func TestIsJobNotDeployedError(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "nil error is not a not-deployed signal", err: nil, want: false},
+		{name: "job not found is authoritative", err: errors.New(`API error: {"detail":"Job not found"}`), want: true},
+		{name: "transform not found is authoritative", err: errors.New(`API error: {"detail":"Transform not found"}`), want: true},
+		{name: "job not found with request_id suffix", err: errors.New(`Job not found (request_id=abc123)`), want: true},
+		{name: "transient 500 is not a not-deployed signal", err: errors.New("500 Internal Server Error"), want: false},
+		{name: "network timeout is not a not-deployed signal", err: errors.New("context deadline exceeded"), want: false},
+		{name: "unrelated 400 is not a not-deployed signal", err: errors.New("validation error: bad request"), want: false},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			got := isJobNotDeployedError(tc.err)
+			if got != tc.want {
+				t.Fatalf("isJobNotDeployedError(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}
 
 func TestStripNullValues(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
## Summary

Fixes [#75](https://github.com/streamkap-com/terraform-provider-streamkap/issues/75) (`streamkap_transform_sql_join` failing with `transform "" reported as existing but not found in list`) and, while in the area, addresses three additional real bugs surfaced by a thorough review of the transform resource. Every change targets an existing bug — no new API surface, no new endpoints, no request/response shape changes.

## What changed

### Issue #75 — adopt-by-name after "already exists"
- `CreateTransform` now reads `Config["transforms.name"]` (the backend's Pydantic alias in `TransformConfig`) instead of `Config["name"]`. The old lookup returned empty string, which was then searched for in the list endpoint and predictably never found.
- `adoptTransformByName` now paginates with `partial_name=` (matches `adoptSourceByName`/`adoptDestinationByName`/`adoptPipelineByName`). The previous unpaginated `ListTransforms` used the backend default `page_size=10`, so adoption silently failed for any tenant with more than 10 transforms.
- On adopt failure, the original "already exists" error is preserved and wrapped with adopt context — mirrors [99e295d](https://github.com/streamkap-com/terraform-provider-streamkap/commit/99e295d) for sources.

### ListTransforms pagination
- Same root cause as above. Sweepers and any other caller now see the full tenant.

### Data source panic guard
- `modelFromAPIObject` indexed `apiObject.Topics[i]` while iterating `apiObject.TopicIDs`. When the API returns mismatched slice lengths (e.g., topics not yet resolved), the provider panicked. Now falls back to a null name.

### `connector_status` handling in Read
- **Import path**: previously set `UNKNOWN` without calling `GetTransformJobStatus`, causing a spurious diff on the first plan after import (and breaking `TestAccTransformMapFilterResource_deploy` Step 2 once the Issue #75 fix unblocked Step 1). Now refreshes via the API.
- **Transient errors**: previously demoted any known-good status (e.g., `RUNNING`) to `UNKNOWN` on any API error, so a 5xx blip silently rewrote state. Now preserves prior value.
- **Authoritative "not deployed"**: when the backend returns detail `"Job not found"` / `"Transform not found"` (HTTPException(404) rewritten to 400 by the handler's broad `except`), we demote to `UNKNOWN` so drift surfaces on the next apply.

### CLAUDE.md — public-repo hygiene section
- Adds an explicit "Public Repository — Content Hygiene" section at the top so future contributions don't leak internal ticket IDs, customer names, private URLs, or credentials. Complements the earlier [91aba27](https://github.com/streamkap-com/terraform-provider-streamkap/commit/91aba27) scrub commit.

## No API contract changes

All HTTP methods, endpoints, and request/response shapes are unchanged. Diff audit:
- `internal/api/transform.go`: same `GET /transforms` endpoint with backend-supported query params (`page`, `page_size`, `partial_name` — all present in `TransformDetailsReq`).
- `internal/resource/transform/base.go`: one additional call site for the existing `GetTransformJobStatus` client method.
- `internal/datasource/transform.go`: pure local slice-bounds guard, no client calls.

## Test plan

- [x] `TestAPIError422_TransformDuplicateName` — adopt-succeeds path after 422.
- [x] `TestAPIError422_TransformDuplicateName_AdoptNotFound` — adopt-fails path preserves original error.
- [x] `TestListTransforms_Paginates` — multi-page iteration, 100+5 = 105 items.
- [x] `TestModelFromAPIObject_MismatchedTopicsAndIDs` — 3 subtests covering the panic guard.
- [x] `TestIsJobNotDeployedError` — 7-case table for the error-detail string match (including `(request_id=...)` suffix).
- [x] Full non-acceptance suite green: `go test -short -timeout 120s -run '^Test[^A]|^TestA[^c]' ./...`
- [ ] Acceptance suite (`TF_ACC=1`): `TestAccTransformMapFilterResource_deploy` Step 2 (import) previously broken by the Issue #75 fix — review agent confirmed empirically that the new Read path restores it. Will verify in CI.

## Review

Two rounds of code review via an independent agent, cross-checked against the backend repo. Both rounds concluded **ready to ship** with only minor (non-blocking) notes, all addressed before commit.

## Not in scope

- `TestAccTransformMapFilterResource_deployWithReplayWindow` fails with a backend-side validator rejecting `replay_window="0"`. Unrelated to this PR; file separately if not already tracked.
- Backend `/job_status` endpoint's broad `except Exception` clause that rewrites 404 to 400 — worth a follow-up fix on the backend to make the client-side detection more robust. Filed separately if helpful.