### PR TITLE
[v2] feat(source/postgresql,mysql): kafka-only heartbeat docs + heartbeat_use_logical_message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
 ## 0.1.0 (Unreleased)
 
 FEATURES:
+
+* **PostgreSQL/MySQL sources**: Document Kafka-only heartbeat mode. Setting
+  `heartbeat_enabled = true` while leaving `heartbeat_data_collection_schema_or_database`
+  unset/null now keeps the connector polling on low-traffic sources without
+  requiring a `streamkap_heartbeat` table or write grant in the source DB.
+  No schema change — the field has always been optional in the provider; this
+  just lights up an existing path that the backend used to reject.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,6 @@
 
 FEATURES:
 
-* **PostgreSQL/MySQL sources**: Document Kafka-only heartbeat mode. Setting
-  `heartbeat_enabled = true` while leaving `heartbeat_data_collection_schema_or_database`
-  unset/null now keeps the connector polling on low-traffic sources without
-  requiring a `streamkap_heartbeat` table or write grant in the source DB.
-  No schema change — the field has always been optional in the provider; this
-  just lights up an existing path that the backend used to reject.
+* **PostgreSQL/MySQL sources**: Document Kafka-only heartbeat mode. Setting `heartbeat_enabled = true` while leaving `heartbeat_data_collection_schema_or_database` unset/null now keeps the connector polling on low-traffic sources without requiring a `streamkap_heartbeat` table or write grant in the source DB. No schema change — the field has always been optional in the provider; this just lights up an existing path that the backend used to reject.
+
+* **PostgreSQL source**: New optional `heartbeat_use_logical_message` (bool, default `false`). When `heartbeat_enabled = true` and this is set, the connector runs `SELECT pg_logical_emit_message(true, ...)` on each beat to advance the replication slot — works on PG14+ primaries with a SELECT-only role and is compatible with read-only mode. No `streamkap_heartbeat` table or write grant required on the source. Resolves ENG-2398.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+## 2.2.0 (June 22, 2026)
+
+### Added
+
+* **PostgreSQL source**: New optional `heartbeat_use_logical_message` (bool, default `false`). When `heartbeat_enabled = true` and this is set, the connector runs `SELECT pg_logical_emit_message(true, ...)` on each beat to advance the replication slot — works on PG14+ primaries with a SELECT-only role and is compatible with read-only mode. No `streamkap_heartbeat` table or write grant required on the source. Resolves ENG-2398.
+
+### Changed
+
+* **PostgreSQL/MySQL sources**: Document Kafka-only heartbeat mode. Setting `heartbeat_enabled = true` while leaving `heartbeat_data_collection_schema_or_database` unset/null now keeps the connector polling on low-traffic sources without requiring a `streamkap_heartbeat` table or write grant in the source DB. No schema change — the field has always been optional in the provider; this just lights up an existing path that the backend used to reject.
+
 ## 2.1.22 (June 22, 2026)
 
 ### Fixed

--- a/docs/resources/source_mysql.md
+++ b/docs/resources/source_mysql.md
@@ -44,12 +44,17 @@ resource "streamkap_source_mysql" "test" {
   database_password                         = var.source_mysql_password
   database_include_list                     = "crm,ecommerce,tst"
   table_include_list                        = "crm.demo,ecommerce.customers,tst.test_id_timestamp"
-  signal_data_collection_schema_or_database = "crm"
+  signal_data_collection_schema_or_database = "crm.streamkap_signal"
   column_include_list                       = "crm[.]demo[.](id|name),ecommerce[.]customers[.](customer_id|email)"
   database_connection_timezone              = "SERVER"
   snapshot_gtid                             = true
   binary_handling_mode                      = "bytes"
   ssh_enabled                               = false
+
+  # Heartbeat keeps the connector polling on low-traffic sources.
+  #   - leave heartbeat_data_collection_schema_or_database unset -> Kafka-only mode (no source-DB write)
+  #   - set it to a database containing a streamkap_heartbeat table -> source-table mode
+  heartbeat_enabled = true
 }
 
 output "example-source-mysql" {
@@ -76,8 +81,8 @@ output "example-source-mysql" {
 - `column_include_list` (String) Comma separated list of columns whitelist regular expressions, format schema[.]table[.](column1|column2|etc)
 - `database_connection_timezone` (String) Set the connection timezone. If set to SERVER, the source will detect the connection time zone from the values configured on the MySQL server session variables 'time_zone' or 'system_time_zone'
 - `database_port` (Number) MySQL Port. For example, 3306
-- `heartbeat_data_collection_schema_or_database` (String) Heartbeat Table Database
-- `heartbeat_enabled` (Boolean) Heartbeats are used to keep the pipeline healthy when there is a low volume of data at times.
+- `heartbeat_data_collection_schema_or_database` (String) Optional. Only takes effect when `heartbeat_enabled` is `true`. Database containing a `streamkap_heartbeat` table — providing this enables source-table heartbeat mode, which writes to the table on each beat to keep the source transaction log active. Leave `null` for Kafka-only heartbeat (no table or write grant required).
+- `heartbeat_enabled` (Boolean) When `true`, emit a periodic heartbeat to a Kafka topic so the connector keeps polling and committing offsets on low-traffic sources. Set `heartbeat_data_collection_schema_or_database` to also write to a `streamkap_heartbeat` table in the source database; leave it `null` for Kafka-only mode. When `false`, neither heartbeat path runs and `heartbeat_data_collection_schema_or_database` is ignored.
 - `insert_static_key_field_1` (String) The name of the static field to be added to the message key.
 - `insert_static_key_field_2` (String) The name of the static field to be added to the message key.
 - `insert_static_key_value_1` (String) The value of the static field to be added to the message key.
@@ -87,7 +92,7 @@ output "example-source-mysql" {
 - `insert_static_value_field_1` (String) The name of the static field to be added to the message value.
 - `insert_static_value_field_2` (String) The name of the static field to be added to the message value.
 - `predicates_istopictoenrich_pattern` (String) Regex pattern to match topics for enrichment
-- `signal_data_collection_schema_or_database` (String) Schema for signal data collection. If connector is in read-only mode (snapshot_gtid="Yes"), set this to null.
+- `signal_data_collection_schema_or_database` (String) Full path to the signal table including database and table name (e.g., `mydb.streamkap_signal`). This table is used for incremental snapshotting. Follow the documentation for creating this table.
 - `snapshot_gtid` (Boolean) GTID snapshots are read only but require some prerequisite settings, including enabling GTID on the source database. See the documentation for more details.
 - `ssh_enabled` (Boolean) Connect via SSH tunnel
 - `ssh_host` (String) Hostname of the SSH server, only required if `ssh_enabled` is true

--- a/docs/resources/source_postgresql.md
+++ b/docs/resources/source_postgresql.md
@@ -36,19 +36,22 @@ variable "source_postgresql_password" {
 }
 
 resource "streamkap_source_postgresql" "example-source-postgresql" {
-  name                                         = "example-source-postgresql"
-  database_hostname                            = var.source_postgresql_hostname
-  database_port                                = 5432
-  database_user                                = "postgresql"
-  database_password                            = var.source_postgresql_password
-  database_dbname                              = "postgres"
-  snapshot_read_only                           = "No"
-  database_sslmode                             = "require"
-  schema_include_list                          = "streamkap"
-  table_include_list                           = "streamkap.customer,streamkap.customer2"
-  signal_data_collection_schema_or_database    = "streamkap"
-  column_include_list                          = "streamkap[.]customer[.](id|name)"
-  heartbeat_enabled                            = false
+  name                                      = "example-source-postgresql"
+  database_hostname                         = var.source_postgresql_hostname
+  database_port                             = 5432
+  database_user                             = "postgresql"
+  database_password                         = var.source_postgresql_password
+  database_dbname                           = "postgres"
+  snapshot_read_only                        = "No"
+  database_sslmode                          = "require"
+  schema_include_list                       = "streamkap"
+  table_include_list                        = "streamkap.customer,streamkap.customer2"
+  signal_data_collection_schema_or_database = "streamkap.streamkap_signal"
+  column_include_list                       = "streamkap[.]customer[.](id|name)"
+  # Heartbeat keeps the connector polling on low-traffic sources.
+  #   - leave heartbeat_data_collection_schema_or_database = null  -> Kafka-only mode (no source-DB write)
+  #   - set it to a schema containing a streamkap_heartbeat table -> source-table mode
+  heartbeat_enabled                            = true
   heartbeat_data_collection_schema_or_database = null
   include_source_db_name_in_table_name         = false
   slot_name                                    = "terraform_pgoutput_slot"
@@ -82,8 +85,8 @@ output "example-source-postgresql" {
 - `column_include_list` (String) An optional, comma-separated list of regular expressions that match the fully-qualified names of columns that should be included in change event record values. Fully-qualified names for columns are of the form schemaName[.]tableName[.](columnName1|columnName2)You can only specify either `column_include_list` or `column_exclude_list`, not both.
 - `database_port` (Number) PostgreSQL Port. For example, 5432
 - `database_sslmode` (String) Whether to use an encrypted connection to the PostgreSQL server
-- `heartbeat_data_collection_schema_or_database` (String) Schema for heartbeat data collection
-- `heartbeat_enabled` (Boolean) Enable heartbeat to keep the pipeline healthy during low data volume
+- `heartbeat_data_collection_schema_or_database` (String) Optional. Only takes effect when `heartbeat_enabled` is `true`. Schema containing a `streamkap_heartbeat` table — providing this enables source-table heartbeat mode, which writes to the table on each beat to keep the source transaction log active. Leave `null` for Kafka-only heartbeat (no table or write grant required).
+- `heartbeat_enabled` (Boolean) When `true`, emit a periodic heartbeat to a Kafka topic so the connector keeps polling and committing offsets on low-traffic sources. Set `heartbeat_data_collection_schema_or_database` to also write to a `streamkap_heartbeat` table in the source database; leave it `null` for Kafka-only mode. When `false`, neither heartbeat path runs and `heartbeat_data_collection_schema_or_database` is ignored.
 - `include_source_db_name_in_table_name` (Boolean) Prefix topics with the database name
 - `insert_static_key_field_1` (String) The name of the static field to be added to the message key.
 - `insert_static_key_field_2` (String) The name of the static field to be added to the message key.
@@ -95,7 +98,7 @@ output "example-source-postgresql" {
 - `insert_static_value_field_2` (String) The name of the static field to be added to the message value.
 - `predicates_istopictoenrich_pattern` (String) Regex pattern to match topics for enrichment
 - `publication_name` (String) Publication name for the connector
-- `signal_data_collection_schema_or_database` (String) Schema for signal data collection
+- `signal_data_collection_schema_or_database` (String) Full path to the signal table including schema and table name (e.g., `public.streamkap_signal`). This table is used for incremental snapshotting. Follow the documentation for creating this table.
 - `slot_name` (String) Replication slot name for the connector
 - `snapshot_read_only` (String) When connecting to a read replica PostgreSQL database, this must be set to 'Yes' to support Streamkap snapshots
 - `ssh_enabled` (Boolean) Connect via SSH tunnel

--- a/examples/resources/streamkap_source_mysql/resource.tf
+++ b/examples/resources/streamkap_source_mysql/resource.tf
@@ -35,6 +35,11 @@ resource "streamkap_source_mysql" "test" {
   snapshot_gtid                             = true
   binary_handling_mode                      = "bytes"
   ssh_enabled                               = false
+
+  # Heartbeat keeps the connector polling on low-traffic sources.
+  #   - leave heartbeat_data_collection_schema_or_database unset -> Kafka-only mode (no source-DB write)
+  #   - set it to a database containing a streamkap_heartbeat table -> source-table mode
+  heartbeat_enabled = false
 }
 
 output "example-source-mysql" {

--- a/examples/resources/streamkap_source_mysql/resource.tf
+++ b/examples/resources/streamkap_source_mysql/resource.tf
@@ -39,7 +39,7 @@ resource "streamkap_source_mysql" "test" {
   # Heartbeat keeps the connector polling on low-traffic sources.
   #   - leave heartbeat_data_collection_schema_or_database unset -> Kafka-only mode (no source-DB write)
   #   - set it to a database containing a streamkap_heartbeat table -> source-table mode
-  heartbeat_enabled = false
+  heartbeat_enabled = true
 }
 
 output "example-source-mysql" {

--- a/examples/resources/streamkap_source_postgresql/resource.tf
+++ b/examples/resources/streamkap_source_postgresql/resource.tf
@@ -33,6 +33,9 @@ resource "streamkap_source_postgresql" "example-source-postgresql" {
   table_include_list                           = "streamkap.customer,streamkap.customer2"
   signal_data_collection_schema_or_database    = "streamkap.streamkap_signal"
   column_include_list                          = "streamkap[.]customer[.](id|name)"
+  # Heartbeat keeps the connector polling on low-traffic sources.
+  #   - leave heartbeat_data_collection_schema_or_database = null  -> Kafka-only mode (no source-DB write)
+  #   - set it to a schema containing a streamkap_heartbeat table -> source-table mode
   heartbeat_enabled                            = false
   heartbeat_data_collection_schema_or_database = null
   include_source_db_name_in_table_name         = false

--- a/examples/resources/streamkap_source_postgresql/resource.tf
+++ b/examples/resources/streamkap_source_postgresql/resource.tf
@@ -21,22 +21,22 @@ variable "source_postgresql_password" {
 }
 
 resource "streamkap_source_postgresql" "example-source-postgresql" {
-  name                                         = "example-source-postgresql"
-  database_hostname                            = var.source_postgresql_hostname
-  database_port                                = 5432
-  database_user                                = "postgresql"
-  database_password                            = var.source_postgresql_password
-  database_dbname                              = "postgres"
-  snapshot_read_only                           = "No"
-  database_sslmode                             = "require"
-  schema_include_list                          = "streamkap"
-  table_include_list                           = "streamkap.customer,streamkap.customer2"
-  signal_data_collection_schema_or_database    = "streamkap.streamkap_signal"
-  column_include_list                          = "streamkap[.]customer[.](id|name)"
+  name                                      = "example-source-postgresql"
+  database_hostname                         = var.source_postgresql_hostname
+  database_port                             = 5432
+  database_user                             = "postgresql"
+  database_password                         = var.source_postgresql_password
+  database_dbname                           = "postgres"
+  snapshot_read_only                        = "No"
+  database_sslmode                          = "require"
+  schema_include_list                       = "streamkap"
+  table_include_list                        = "streamkap.customer,streamkap.customer2"
+  signal_data_collection_schema_or_database = "streamkap.streamkap_signal"
+  column_include_list                       = "streamkap[.]customer[.](id|name)"
   # Heartbeat keeps the connector polling on low-traffic sources.
   #   - leave heartbeat_data_collection_schema_or_database = null  -> Kafka-only mode (no source-DB write)
   #   - set it to a schema containing a streamkap_heartbeat table -> source-table mode
-  heartbeat_enabled                            = false
+  heartbeat_enabled                            = true
   heartbeat_data_collection_schema_or_database = null
   include_source_db_name_in_table_name         = false
   slot_name                                    = "terraform_pgoutput_slot"

--- a/examples/resources/streamkap_source_postgresql/resource.tf
+++ b/examples/resources/streamkap_source_postgresql/resource.tf
@@ -38,6 +38,7 @@ resource "streamkap_source_postgresql" "example-source-postgresql" {
   #   - set it to a schema containing a streamkap_heartbeat table -> source-table mode
   heartbeat_enabled                            = true
   heartbeat_data_collection_schema_or_database = null
+  # heartbeat_use_logical_message              = true  # PG14+, SELECT-only role, read-only-compatible
   include_source_db_name_in_table_name         = false
   slot_name                                    = "terraform_pgoutput_slot"
   publication_name                             = "terraform_pub"

--- a/internal/resource/source/mysql.go
+++ b/internal/resource/source/mysql.go
@@ -149,16 +149,26 @@ func (r *SourceMySQLResource) Schema(ctx context.Context, req res.SchemaRequest,
 				MarkdownDescription: "Comma separated list of columns blacklist regular expressions, format schema[.]table[.](column1|column2|etc)",
 			},
 			"heartbeat_enabled": schema.BoolAttribute{
-				Computed:            true,
-				Optional:            true,
-				Default:             booldefault.StaticBool(false),
-				Description:         "Heartbeats are used to keep the pipeline healthy when there is a low volume of data at times.",
-				MarkdownDescription: "Heartbeats are used to keep the pipeline healthy when there is a low volume of data at times.",
+				Computed: true,
+				Optional: true,
+				Default:  booldefault.StaticBool(false),
+				Description: "Emit a periodic heartbeat to a Kafka topic so the connector keeps " +
+					"polling and committing offsets on low-traffic sources. " +
+					"Set heartbeat_data_collection_schema_or_database to also write to a streamkap_heartbeat " +
+					"table in the source database; leave it null for Kafka-only mode.",
+				MarkdownDescription: "Emit a periodic heartbeat to a Kafka topic so the connector keeps " +
+					"polling and committing offsets on low-traffic sources. " +
+					"Set `heartbeat_data_collection_schema_or_database` to also write to a `streamkap_heartbeat` " +
+					"table in the source database; leave it `null` for Kafka-only mode.",
 			},
 			"heartbeat_data_collection_schema_or_database": schema.StringAttribute{
-				Optional:            true,
-				Description:         "Heartbeat Table Database",
-				MarkdownDescription: "Heartbeat Table Database",
+				Optional: true,
+				Description: "Optional. Database containing a streamkap_heartbeat table — providing this enables " +
+					"source-table heartbeat mode, which writes to the table on each beat to keep the " +
+					"source transaction log active. Leave null for Kafka-only heartbeat (no table or write grant required).",
+				MarkdownDescription: "Optional. Database containing a `streamkap_heartbeat` table — providing this enables " +
+					"source-table heartbeat mode, which writes to the table on each beat to keep the " +
+					"source transaction log active. Leave `null` for Kafka-only heartbeat (no table or write grant required).",
 			},
 			"database_connection_timezone": schema.StringAttribute{
 				Computed:            true,

--- a/internal/resource/source/mysql.go
+++ b/internal/resource/source/mysql.go
@@ -152,22 +152,24 @@ func (r *SourceMySQLResource) Schema(ctx context.Context, req res.SchemaRequest,
 				Computed: true,
 				Optional: true,
 				Default:  booldefault.StaticBool(false),
-				Description: "Emit a periodic heartbeat to a Kafka topic so the connector keeps " +
+				Description: "When true, emit a periodic heartbeat to a Kafka topic so the connector keeps " +
 					"polling and committing offsets on low-traffic sources. " +
 					"Set heartbeat_data_collection_schema_or_database to also write to a streamkap_heartbeat " +
-					"table in the source database; leave it null for Kafka-only mode.",
-				MarkdownDescription: "Emit a periodic heartbeat to a Kafka topic so the connector keeps " +
+					"table in the source database; leave it null for Kafka-only mode. " +
+					"When false, neither heartbeat path runs and heartbeat_data_collection_schema_or_database is ignored.",
+				MarkdownDescription: "When `true`, emit a periodic heartbeat to a Kafka topic so the connector keeps " +
 					"polling and committing offsets on low-traffic sources. " +
 					"Set `heartbeat_data_collection_schema_or_database` to also write to a `streamkap_heartbeat` " +
-					"table in the source database; leave it `null` for Kafka-only mode.",
+					"table in the source database; leave it `null` for Kafka-only mode. " +
+					"When `false`, neither heartbeat path runs and `heartbeat_data_collection_schema_or_database` is ignored.",
 			},
 			"heartbeat_data_collection_schema_or_database": schema.StringAttribute{
 				Optional: true,
-				Description: "Optional. Database containing a streamkap_heartbeat table — providing this enables " +
-					"source-table heartbeat mode, which writes to the table on each beat to keep the " +
+				Description: "Optional. Only takes effect when heartbeat_enabled is true. Database containing a streamkap_heartbeat " +
+					"table — providing this enables source-table heartbeat mode, which writes to the table on each beat to keep the " +
 					"source transaction log active. Leave null for Kafka-only heartbeat (no table or write grant required).",
-				MarkdownDescription: "Optional. Database containing a `streamkap_heartbeat` table — providing this enables " +
-					"source-table heartbeat mode, which writes to the table on each beat to keep the " +
+				MarkdownDescription: "Optional. Only takes effect when `heartbeat_enabled` is `true`. Database containing a `streamkap_heartbeat` " +
+					"table — providing this enables source-table heartbeat mode, which writes to the table on each beat to keep the " +
 					"source transaction log active. Leave `null` for Kafka-only heartbeat (no table or write grant required).",
 			},
 			"database_connection_timezone": schema.StringAttribute{

--- a/internal/resource/source/postgresql.go
+++ b/internal/resource/source/postgresql.go
@@ -194,16 +194,26 @@ func (r *SourcePostgreSQLResource) Schema(ctx context.Context, req res.SchemaReq
 					"You can only specify either `column_include_list` or `column_exclude_list`, not both.",
 			},
 			"heartbeat_enabled": schema.BoolAttribute{
-				Computed:            true,
-				Optional:            true,
-				Default:             booldefault.StaticBool(false),
-				Description:         "Enable heartbeat to keep the pipeline healthy during low data volume",
-				MarkdownDescription: "Enable heartbeat to keep the pipeline healthy during low data volume",
+				Computed: true,
+				Optional: true,
+				Default:  booldefault.StaticBool(false),
+				Description: "Emit a periodic heartbeat to a Kafka topic so the connector keeps " +
+					"polling and committing offsets on low-traffic sources. " +
+					"Set heartbeat_data_collection_schema_or_database to also write to a streamkap_heartbeat " +
+					"table in the source database; leave it null for Kafka-only mode.",
+				MarkdownDescription: "Emit a periodic heartbeat to a Kafka topic so the connector keeps " +
+					"polling and committing offsets on low-traffic sources. " +
+					"Set `heartbeat_data_collection_schema_or_database` to also write to a `streamkap_heartbeat` " +
+					"table in the source database; leave it `null` for Kafka-only mode.",
 			},
 			"heartbeat_data_collection_schema_or_database": schema.StringAttribute{
-				Optional:            true,
-				Description:         "Schema for heartbeat data collection",
-				MarkdownDescription: "Schema for heartbeat data collection",
+				Optional: true,
+				Description: "Optional. Schema containing a streamkap_heartbeat table — providing this enables " +
+					"source-table heartbeat mode, which writes to the table on each beat to keep the " +
+					"source transaction log active. Leave null for Kafka-only heartbeat (no table or write grant required).",
+				MarkdownDescription: "Optional. Schema containing a `streamkap_heartbeat` table — providing this enables " +
+					"source-table heartbeat mode, which writes to the table on each beat to keep the " +
+					"source transaction log active. Leave `null` for Kafka-only heartbeat (no table or write grant required).",
 			},
 			"include_source_db_name_in_table_name": schema.BoolAttribute{
 				Computed:            true,

--- a/internal/resource/source/postgresql.go
+++ b/internal/resource/source/postgresql.go
@@ -197,22 +197,24 @@ func (r *SourcePostgreSQLResource) Schema(ctx context.Context, req res.SchemaReq
 				Computed: true,
 				Optional: true,
 				Default:  booldefault.StaticBool(false),
-				Description: "Emit a periodic heartbeat to a Kafka topic so the connector keeps " +
+				Description: "When true, emit a periodic heartbeat to a Kafka topic so the connector keeps " +
 					"polling and committing offsets on low-traffic sources. " +
 					"Set heartbeat_data_collection_schema_or_database to also write to a streamkap_heartbeat " +
-					"table in the source database; leave it null for Kafka-only mode.",
-				MarkdownDescription: "Emit a periodic heartbeat to a Kafka topic so the connector keeps " +
+					"table in the source database; leave it null for Kafka-only mode. " +
+					"When false, neither heartbeat path runs and heartbeat_data_collection_schema_or_database is ignored.",
+				MarkdownDescription: "When `true`, emit a periodic heartbeat to a Kafka topic so the connector keeps " +
 					"polling and committing offsets on low-traffic sources. " +
 					"Set `heartbeat_data_collection_schema_or_database` to also write to a `streamkap_heartbeat` " +
-					"table in the source database; leave it `null` for Kafka-only mode.",
+					"table in the source database; leave it `null` for Kafka-only mode. " +
+					"When `false`, neither heartbeat path runs and `heartbeat_data_collection_schema_or_database` is ignored.",
 			},
 			"heartbeat_data_collection_schema_or_database": schema.StringAttribute{
 				Optional: true,
-				Description: "Optional. Schema containing a streamkap_heartbeat table — providing this enables " +
-					"source-table heartbeat mode, which writes to the table on each beat to keep the " +
+				Description: "Optional. Only takes effect when heartbeat_enabled is true. Schema containing a streamkap_heartbeat " +
+					"table — providing this enables source-table heartbeat mode, which writes to the table on each beat to keep the " +
 					"source transaction log active. Leave null for Kafka-only heartbeat (no table or write grant required).",
-				MarkdownDescription: "Optional. Schema containing a `streamkap_heartbeat` table — providing this enables " +
-					"source-table heartbeat mode, which writes to the table on each beat to keep the " +
+				MarkdownDescription: "Optional. Only takes effect when `heartbeat_enabled` is `true`. Schema containing a `streamkap_heartbeat` " +
+					"table — providing this enables source-table heartbeat mode, which writes to the table on each beat to keep the " +
 					"source transaction log active. Leave `null` for Kafka-only heartbeat (no table or write grant required).",
 			},
 			"include_source_db_name_in_table_name": schema.BoolAttribute{

--- a/internal/resource/source/postgresql.go
+++ b/internal/resource/source/postgresql.go
@@ -57,6 +57,7 @@ type SourcePostgreSQLResourceModel struct {
 	ColumnExcludeList                       types.String `tfsdk:"column_exclude_list"`
 	HeartbeatEnabled                        types.Bool   `tfsdk:"heartbeat_enabled"`
 	HeartbeatDataCollectionSchemaOrDatabase types.String `tfsdk:"heartbeat_data_collection_schema_or_database"`
+	HeartbeatUseLogicalMessage              types.Bool   `tfsdk:"heartbeat_use_logical_message"`
 	IncludeSourceDBNameInTableName          types.Bool   `tfsdk:"include_source_db_name_in_table_name"`
 	SlotName                                types.String `tfsdk:"slot_name"`
 	PublicationName                         types.String `tfsdk:"publication_name"`
@@ -216,6 +217,21 @@ func (r *SourcePostgreSQLResource) Schema(ctx context.Context, req res.SchemaReq
 				MarkdownDescription: "Optional. Only takes effect when `heartbeat_enabled` is `true`. Schema containing a `streamkap_heartbeat` " +
 					"table — providing this enables source-table heartbeat mode, which writes to the table on each beat to keep the " +
 					"source transaction log active. Leave `null` for Kafka-only heartbeat (no table or write grant required).",
+			},
+			"heartbeat_use_logical_message": schema.BoolAttribute{
+				Computed: true,
+				Optional: true,
+				Default:  booldefault.StaticBool(false),
+				Description: "Use a logical-message heartbeat instead of a heartbeat table. Runs " +
+					"SELECT pg_logical_emit_message(true, ...) on each beat to keep the replication " +
+					"slot advancing — works on PG14+ primaries with a SELECT-only role and is " +
+					"compatible with read-only mode. No table or write grant required on the source. " +
+					"Only takes effect when heartbeat_enabled is true.",
+				MarkdownDescription: "Use a logical-message heartbeat instead of a heartbeat table. Runs " +
+					"`SELECT pg_logical_emit_message(true, ...)` on each beat to keep the replication " +
+					"slot advancing — works on PG14+ primaries with a SELECT-only role and is " +
+					"compatible with read-only mode. No table or write grant required on the source. " +
+					"Only takes effect when `heartbeat_enabled` is `true`.",
 			},
 			"include_source_db_name_in_table_name": schema.BoolAttribute{
 				Computed:            true,
@@ -519,6 +535,7 @@ func (r *SourcePostgreSQLResource) model2ConfigMap(model SourcePostgreSQLResourc
 		"column.include.list.toggled":                       true,
 		"heartbeat.enabled":                                 model.HeartbeatEnabled.ValueBool(),
 		"heartbeat.data.collection.schema.or.database":      model.HeartbeatDataCollectionSchemaOrDatabase.ValueStringPointer(),
+		"heartbeat.use.logical.message":                     model.HeartbeatUseLogicalMessage.ValueBool(),
 		"include.source.db.name.in.table.name.user.defined": model.IncludeSourceDBNameInTableName.ValueBool(),
 		"slot.name":                                         model.SlotName.ValueString(),
 		"publication.name":                                  model.PublicationName.ValueString(),
@@ -565,6 +582,7 @@ func (r *SourcePostgreSQLResource) configMap2Model(cfg map[string]any, model *So
 	model.ColumnExcludeList = helper.GetTfCfgString(cfg, "column.exclude.list.user.defined")
 	model.HeartbeatEnabled = helper.GetTfCfgBool(cfg, "heartbeat.enabled")
 	model.HeartbeatDataCollectionSchemaOrDatabase = helper.GetTfCfgString(cfg, "heartbeat.data.collection.schema.or.database")
+	model.HeartbeatUseLogicalMessage = helper.GetTfCfgBool(cfg, "heartbeat.use.logical.message")
 	model.IncludeSourceDBNameInTableName = helper.GetTfCfgBool(cfg, "include.source.db.name.in.table.name.user.defined")
 	model.SlotName = helper.GetTfCfgString(cfg, "slot.name")
 	model.PublicationName = helper.GetTfCfgString(cfg, "publication.name")


### PR DESCRIPTION
**Target:** v2 (`main` — stable). Supersedes #88.

Two pieces in one PR, both v2-only and both PostgreSQL/MySQL heartbeat-related.

**1. Kafka-only heartbeat mode — documentation.** Setting `heartbeat_enabled = true` while leaving `heartbeat_data_collection_schema_or_database` unset now keeps the connector polling on low-traffic sources without requiring a `streamkap_heartbeat` table or write grant in the source DB. No provider-side schema or default changes — the field was always optional; this PR documents the path the backend [recently lit up](https://github.com/streamkap-com/backend/pull/2173). Updates `heartbeat_enabled` and `heartbeat_data_collection_schema_or_database` descriptions on PostgreSQL and MySQL, annotates examples, regenerates the two affected registry doc pages.

**2. New attribute — `heartbeat_use_logical_message`** (bool, default `false`) on `streamkap_source_postgresql`. When `heartbeat_enabled = true` and this is set, the connector advances the replication slot by emitting `pg_logical_emit_message(true, ...)` on each beat. Works on PG14+ primaries with a SELECT-only role and is compatible with read-only mode — no `streamkap_heartbeat` table or write grant required on the source. Resolves [ENG-2398](https://linear.app/streamkap/issue/ENG-2398).

**Behavior:** new attribute defaults to `false`, so existing configurations are unaffected. Verified end-to-end against the dev tenant cycling through all five `(heartbeat_enabled, heartbeat_data_collection_schema_or_database, heartbeat_use_logical_message)` combinations — clean Create / Update / Read round-trips with no drift.

**Breaking changes:** none.

**Why `heartbeat_enabled` still defaults to `false` on v2:** the UI defaults heartbeats on, but flipping the v2 schema default would silently turn heartbeats on for every existing Terraform-managed source on the next `apply`. `main` is back-compat-only, so the default-on alignment lives on `develop` (see #87).

SQL Server source held back from the Kafka-only doc update — its `default = "streamkap"` on the schema field prevents Kafka-only mode reaching here without a behavior change. Tracked separately. `go generate` housekeeping for unrelated stale docs deferred to a separate PR.