### PR TITLE
fix(pipeline,transform): refuse to auto-adopt on name conflict (data-loss fix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,58 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **`streamkap_pipeline` and `streamkap_transform_*` no longer auto-adopt on
+  duplicate-name conflicts (409 / 422 "already exists").** The previous
+  adopt-on-conflict path was unsafe under
+  `lifecycle { create_before_destroy = true }`: Terraform creates the new
+  instance first while the deposed instance still occupies the
+  `{tenant_id, service_id, name}` slot, the provider would adopt the
+  deposed's backend record (returning the same backend id from Create), and
+  Terraform's subsequent destroy of the deposed entry would DELETE the same
+  backend record the live state had just been pointed at — silently
+  destroying the customer's live pipeline / transform. A customer hit this on
+  pipelines and had deposed transforms in the same state that would have
+  triggered the same issue once the pipeline path was unblocked
+  (trace in `0_Terraform Apply.txt`). The provider now refuses to auto-adopt
+  on these two resources and surfaces a clear error with two recovery paths:
+    1. Remove `create_before_destroy = true` from the resource's
+       `lifecycle` (Streamkap enforces unique pipeline / transform names per
+       tenant + service, so that lifecycle does not work).
+    2. `terraform import streamkap_pipeline.<name> <pipeline_id>` or
+       `terraform import streamkap_transform_<type>.<name> <transform_id>`
+       when recovering from a previous apply whose response was lost.
+  The original adopt-on-conflict still applies to `streamkap_source_*`,
+  `streamkap_destination_*`, and `streamkap_tag`. The **same data-loss path
+  exists in principle** for those resources — adopt-on-conflict under
+  `create_before_destroy` is unsafe for any backend that enforces
+  name-uniqueness, regardless of resource type. We are holding their adopt
+  path back from this PR because (a) the reported customer wasn't hitting
+  it on those resources, (b) existing acceptance tests rely on adopt-on-422
+  behavior there, and (c) tightening them would break legitimate
+  timed-out-create recovery workflows. This is **not** a statement that
+  they are safe; track removing their adopt path in a follow-up before any
+  customer relies on `lifecycle { create_before_destroy = true }` against
+  those resources.
+- **`streamkap_transform_*` — `deploy = true` with `replay_window = "0"`
+  failed with "Replay window must be a valid duration like 3d, 10m, 2h, 30s".**
+  The provider's schema documents `"0"` as "continue from last position"
+  (semantically identical to leaving the field unset → backend's
+  `start_time = None` → use the latest offset). But the backend's preview-
+  deploy parser uses a strict `(\d+)([smhd])` regex
+  (`python-be-streamkap/app/utils/api/v2/api_transforms_utils.py:352`) that
+  rejects a bare `"0"`. The deploy client now treats `"0"` and `""` as
+  equivalent and omits the query parameter in both cases, restoring the
+  documented behavior without requiring a backend change.
+- **Non-JSON error responses surface a useful message.** When an upstream
+  layer (nginx, load balancer, ingress) returned HTML or another non-JSON
+  body for a 5xx, the client previously bubbled up a bare
+  `invalid character '<' looking for beginning of value` JSON-decode error
+  — the HTTP status and body content were silently dropped, which dead-ended
+  customer debugging. Error responses that fail to decode as the standard
+  `{"detail": "..."}` shape now surface the actual status code and a
+  truncated body snippet so the real failure is visible.
+
 ## [3.0.0-beta.15] - 2026-05-08 (Pre-release)
 
 ### Added

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -402,6 +402,48 @@ resource "streamkap_transform_map_filter" "example" {
 - `streamkap_destination_kafka` - Kafka destination
 - `streamkap_destination_iceberg` - Iceberg destination
 
+## Known limitations
+
+### `streamkap_pipeline` and `streamkap_transform_*` do not support `lifecycle { create_before_destroy = true }`
+
+Streamkap enforces unique pipeline and transform names per
+`{tenant_id, service_id}`. The `create_before_destroy` lifecycle requires the
+old and new instances to coexist briefly during the apply, which the backend
+will reject with a 409 (pipelines) / 422 (transforms) conflict. Symptoms:
+
+- `Error: streamkap_pipeline "<name>" already exists ...` or
+  `Error: streamkap_transform "<name>" already exists ...`, with a backend
+  409 / 422 in the debug log.
+- After repeated retries with the old provider version, deposed instances
+  accumulate in state (visible as
+  `streamkap_pipeline.<name> (destroy deposed <key>)` or
+  `streamkap_transform_<type>.<name> (destroy deposed <key>)` in
+  `terraform plan`).
+
+The provider now refuses to auto-adopt on this collision and surfaces an
+actionable error. To recover:
+
+1. **Remove the lifecycle directive** — for `streamkap_pipeline` and the
+   `streamkap_transform_*` resources, use the default destroy-then-create. If
+   you specifically need create-before-destroy semantics, rename the resource
+   so old and new can coexist by name.
+2. **If you have accumulated deposed entries**, clean them up with
+   `terraform state rm '<resource_address>.deposed.<key>'` (one for each
+   deposed entry; quote the address because of the dot), then re-run apply.
+3. **If the resource already exists on the backend but not in state** (e.g.
+   from a previous apply whose response was lost), use `terraform import`
+   to bring it into state and then `terraform apply` to reconcile any drift.
+   - Pipelines:
+     `terraform import streamkap_pipeline.<name> <pipeline_id>`
+   - Transforms: the resource type matches the existing record's `transform`
+     field (e.g. `sql_join` → `streamkap_transform_sql_join`,
+     `map_filter` → `streamkap_transform_map_filter`):
+     `terraform import streamkap_transform_sql_join.<name> <transform_id>`
+
+The id (and `transform` type for transforms) is visible in the Streamkap UI
+or via `GET /pipelines?partial_name=<name>` /
+`GET /transforms?partial_name=<name>`.
+
 ## Deprecation Timeline
 
 | Version | Status |

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
@@ -135,32 +136,60 @@ func (s *streamkapAPI) doRequest(ctx context.Context, req *http.Request, result 
 		tflog.Debug(ctx, fmt.Sprintf("%s %s → %d (request_id=%s)", req.Method, req.URL, resp.StatusCode, requestID))
 	}
 
-	respBodyDecoder := json.NewDecoder(resp.Body)
 	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		// Read the body once so we can both attempt JSON decode and fall back
+		// to surfacing the raw response. The backend's normal error shape is
+		// `{"detail": "..."}` but a non-2xx can also come from intermediate
+		// layers (nginx 502/504, load-balancer, auth redirect) and arrive as
+		// HTML. Returning only the bare JSON parse error ("invalid character
+		// '<' looking for beginning of value") strips the status code and
+		// every actionable hint, which has been a recurring debugging
+		// dead-end for users.
+		bodyBytes, readErr := io.ReadAll(resp.Body)
+		if readErr != nil {
+			return fmt.Errorf("%s %s → %d: failed to read error body: %w", req.Method, req.URL, resp.StatusCode, readErr)
+		}
 		var apiErr APIErrorResponse
-		if err := respBodyDecoder.Decode(&apiErr); err != nil {
-			tflog.Debug(ctx,
-				fmt.Sprintf("%s request to %s got status code: %d. Failed to parse API error response: %v",
-					req.Method,
-					req.URL,
-					resp.StatusCode,
-					err,
-				),
-			)
-			return err
-		} else {
+		if jsonErr := json.Unmarshal(bodyBytes, &apiErr); jsonErr == nil && apiErr.Detail != "" {
 			detail := apiErr.Detail
 			if requestID != "" {
 				detail = fmt.Sprintf("%s (request_id=%s)", detail, requestID)
 			}
 			return errors.New(detail)
 		}
+		tflog.Debug(ctx,
+			fmt.Sprintf("%s %s → %d: response body not JSON: %s",
+				req.Method, req.URL, resp.StatusCode, snippet(bodyBytes)),
+		)
+		detail := fmt.Sprintf("%s %s → HTTP %d (non-JSON response body: %s)",
+			req.Method, req.URL, resp.StatusCode, snippet(bodyBytes))
+		if requestID != "" {
+			detail = fmt.Sprintf("%s (request_id=%s)", detail, requestID)
+		}
+		return errors.New(detail)
 	}
 
-	if err := respBodyDecoder.Decode(result); err != nil {
+	if err := json.NewDecoder(resp.Body).Decode(result); err != nil {
 		return err
 	}
 	return nil
+}
+
+// snippet trims a response body to a single-line preview suitable for error
+// messages. Used for surfacing HTML/non-JSON error bodies that would
+// otherwise be lost behind a bare json-decoder error.
+func snippet(b []byte) string {
+	const maxLen = 200
+	s := strings.TrimSpace(string(b))
+	s = strings.ReplaceAll(s, "\n", " ")
+	s = strings.ReplaceAll(s, "\r", " ")
+	if len(s) > maxLen {
+		s = s[:maxLen] + "...[truncated]"
+	}
+	if s == "" {
+		s = "(empty body)"
+	}
+	return s
 }
 
 // doRequestWithRetry wraps doRequest with retry logic for transient errors.

--- a/internal/api/pipeline.go
+++ b/internal/api/pipeline.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"net/url"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-log/tflog"
@@ -86,50 +85,51 @@ func (s *streamkapAPI) CreatePipeline(ctx context.Context, reqPayload Pipeline) 
 	var resp Pipeline
 	err = s.doRequestWithRetry(ctx, req, &resp)
 	if err != nil {
-		// Create-or-adopt: if a pipeline with this name already exists (409 from a
-		// previous timed-out create), adopt the existing one instead of failing.
+		// Do NOT auto-adopt pipelines on 409. Streamkap enforces unique
+		// {tenant_id, service_id, name} for pipelines, so a 409 means one
+		// already exists with this name. Two scenarios produce it:
+		//
+		//   1. A previous apply created the pipeline but lost the response
+		//      (network, timeout) — Terraform's state thinks the resource
+		//      doesn't exist but the backend has it. Recovery: `terraform
+		//      import`.
+		//
+		//   2. A `lifecycle { create_before_destroy = true }` replace
+		//      operation is in flight: Terraform created a *deposed* state
+		//      entry from the old live instance (id=X), then asked the
+		//      provider to create the *new* live instance, which collides
+		//      on name with the still-existing backend pipeline X.
+		//
+		// An earlier version of this code adopted the existing pipeline by
+		// name and returned it as the create result. That is *unsafe* under
+		// scenario 2: the new live state entry would end up with the same
+		// backend id as the deposed entry, and the next step of the apply
+		// (destroy the deposed) would DELETE the very pipeline we just
+		// "adopted", leaving the live state pointing at a tombstone. We
+		// confirmed this trace against a real customer log
+		// (0_Terraform Apply.txt) — they had 4 deposed entries all pointing
+		// to the same backend pipeline because of repeated adoption.
+		//
+		// We can't disambiguate the two scenarios from inside the API
+		// client (no state visibility) and a content-comparison adopt is
+		// also unsafe (taint + create_before_destroy + no config change
+		// collapses to the same data-loss). So we surface a clear error
+		// and leave recovery to the user. Loud failure beats silent data
+		// loss.
 		if strings.Contains(err.Error(), "already exists") {
-			tflog.Info(ctx, fmt.Sprintf(
-				"Pipeline %q already exists — attempting to adopt existing resource", reqPayload.Name))
-			adopted, adoptErr := s.adoptPipelineByName(ctx, reqPayload.Name)
-			if adoptErr == nil {
-				return adopted, nil
-			}
-			// See matching comment in source.go CreateSource.
-			return nil, fmt.Errorf("%w (also tried to adopt the existing resource but could not locate it via the list endpoint: %v)", err, adoptErr)
+			return nil, fmt.Errorf(
+				"streamkap_pipeline %q already exists on the backend, and auto-adoption is unsafe for this resource (would risk destroying the live pipeline under create_before_destroy). Recovery options:\n"+
+					"  • If this is a `lifecycle { create_before_destroy = true }` replace: remove that directive — Streamkap enforces unique pipeline names per tenant/service so a new and an old pipeline cannot coexist by name. Use the default destroy-then-create, or change the pipeline name so old and new can briefly coexist.\n"+
+					"  • If you already have deposed entries from previous failed applies (visible in `terraform plan` as `<address> (destroy deposed <key>)`), they point at the same backend record and must be removed from state before any retry will work: `terraform state rm '<resource_address>'` (Terraform will refuse the deposed-key bit automatically; the address alone removes both live and deposed copies). See docs/MIGRATION.md → \"Known limitations\".\n"+
+					"  • If this is recovering from a previous apply that lost its response: run `terraform import streamkap_pipeline.<resource_name> <pipeline_id>` (find the id via the Streamkap UI or `GET /pipelines?partial_name=%s`) and re-run apply.\n"+
+					"Original backend error: %w",
+				reqPayload.Name, reqPayload.Name, err,
+			)
 		}
 		return nil, err
 	}
 
 	return &resp, nil
-}
-
-// adoptPipelineByName — see adoptSourceByName for rationale (paginates
-// through all partial_name matches to find the exact-name pipeline).
-func (s *streamkapAPI) adoptPipelineByName(ctx context.Context, name string) (*Pipeline, error) {
-	const pageSize = 100
-	const maxPages = 1000
-	for page := 1; page <= maxPages; page++ {
-		reqURL := fmt.Sprintf("%s/pipelines?secret_returned=true&page=%d&page_size=%d&partial_name=%s",
-			s.cfg.BaseURL, page, pageSize, url.QueryEscape(name))
-		req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, http.NoBody)
-		if err != nil {
-			return nil, fmt.Errorf("failed to build adopt request for %q: %w", name, err)
-		}
-		var resp GetPipelineResponse
-		if err := s.doRequest(ctx, req, &resp); err != nil {
-			return nil, fmt.Errorf("failed to list pipelines while adopting %q: %w", name, err)
-		}
-		for i := range resp.Result {
-			if resp.Result[i].Name == name {
-				return &resp.Result[i], nil
-			}
-		}
-		if len(resp.Result) < pageSize {
-			break
-		}
-	}
-	return nil, fmt.Errorf("pipeline %q reported as existing but not found in list", name)
 }
 
 func (s *streamkapAPI) GetPipeline(ctx context.Context, pipelineID string) (*Pipeline, error) {

--- a/internal/api/transform.go
+++ b/internal/api/transform.go
@@ -132,52 +132,44 @@ func (s *streamkapAPI) CreateTransform(ctx context.Context, reqPayload CreateTra
 	var resp Transform
 	err = s.doRequestWithRetry(ctx, req, &resp)
 	if err != nil {
+		// Do NOT auto-adopt transforms on "already exists". The backend
+		// enforces unique transform names per tenant/service, so this
+		// collision arises from one of two scenarios: (a) a previous apply
+		// created the transform but lost the response, or (b) a
+		// `lifecycle { create_before_destroy = true }` replace is in flight
+		// and the deposed instance still occupies the name slot.
+		//
+		// Adopting (looking up by name and returning the existing record)
+		// is *unsafe* under (b): the new live state entry ends up with the
+		// same backend id as the deposed entry, and Terraform's subsequent
+		// destroy of the deposed entry DELETEs the same backend transform
+		// the live state was just pointed at — silently destroying the
+		// customer's transform. The pipeline resource hit this exact
+		// pattern; see internal/api/pipeline.go for the longer write-up
+		// and the customer trace (0_Terraform Apply.txt referenced
+		// deposed transform entries: `transform_sql_join.live[0]
+		// (destroy deposed cd669fa8)` and similar).
+		//
+		// We can't disambiguate the two scenarios from inside the API
+		// client (no state visibility), and a content-comparison adopt is
+		// also unsafe (taint + create_before_destroy + no config change
+		// collapses to the same data-loss). So we surface a clear error
+		// and leave recovery to the user.
 		if strings.Contains(err.Error(), "already exists") {
-			// The transform name lives inside the config map under the
-			// backend's alias "transforms.name" (see base.go Create), not at
-			// the top level like sources/destinations.
 			name, _ := reqPayload.Config["transforms.name"].(string)
-			tflog.Info(ctx, fmt.Sprintf(
-				"Transform %q already exists — attempting to adopt existing resource", name))
-			adopted, adoptErr := s.adoptTransformByName(ctx, name)
-			if adoptErr == nil {
-				return adopted, nil
-			}
-			// See matching comment in source.go CreateSource.
-			return nil, fmt.Errorf("%w (also tried to adopt the existing resource but could not locate it via the list endpoint: %v)", err, adoptErr)
+			return nil, fmt.Errorf(
+				"streamkap_transform %q already exists on the backend, and auto-adoption is unsafe for this resource (would risk destroying the live transform under create_before_destroy). Recovery options:\n"+
+					"  • If this is a `lifecycle { create_before_destroy = true }` replace: remove that directive — Streamkap enforces unique transform names per tenant/service so a new and an old transform cannot coexist by name. Use the default destroy-then-create, or change the transform name so old and new can briefly coexist.\n"+
+					"  • If you already have deposed entries from previous failed applies (visible in `terraform plan` as `<address> (destroy deposed <key>)`), they point at the same backend record and must be removed from state before any retry will work: `terraform state rm '<resource_address>'`. See docs/MIGRATION.md → \"Known limitations\".\n"+
+					"  • If this is recovering from a previous apply that lost its response: run `terraform import streamkap_transform_<type>.<resource_name> <transform_id>`, where `<type>` matches the existing record's `transform` field (e.g. `streamkap_transform_sql_join`, `streamkap_transform_map_filter`). Find the id and type via the Streamkap UI or `GET /transforms?partial_name=%s`, then re-run apply.\n"+
+					"Original backend error: %w",
+				name, name, err,
+			)
 		}
 		return nil, err
 	}
 
 	return &resp, nil
-}
-
-// adoptTransformByName — see adoptSourceByName for rationale (paginates
-// through all partial_name matches to find the exact-name transform).
-func (s *streamkapAPI) adoptTransformByName(ctx context.Context, name string) (*Transform, error) {
-	const pageSize = 100
-	const maxPages = 1000
-	for page := 1; page <= maxPages; page++ {
-		reqURL := fmt.Sprintf("%s/transforms?secret_returned=true&page=%d&page_size=%d&partial_name=%s",
-			s.cfg.BaseURL, page, pageSize, url.QueryEscape(name))
-		req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, http.NoBody)
-		if err != nil {
-			return nil, fmt.Errorf("failed to build adopt request for %q: %w", name, err)
-		}
-		var resp GetTransformResponse
-		if err := s.doRequest(ctx, req, &resp); err != nil {
-			return nil, fmt.Errorf("failed to list transforms while adopting %q: %w", name, err)
-		}
-		for i := range resp.Result {
-			if resp.Result[i].Name == name {
-				return &resp.Result[i], nil
-			}
-		}
-		if len(resp.Result) < pageSize {
-			break
-		}
-	}
-	return nil, fmt.Errorf("transform %q reported as existing but not found in list", name)
 }
 
 func (s *streamkapAPI) UpdateTransform(ctx context.Context, transformID string, reqPayload UpdateTransformRequest) (*Transform, error) {
@@ -313,10 +305,18 @@ func (s *streamkapAPI) UpdateTransformImplementationDetails(ctx context.Context,
 
 // DeployTransformPreview triggers a preview deployment for a transform.
 // versionID should be "no-version" (backend normalizes to "0").
-// replayWindow examples: "7d", "24h", "10m", "0", "" (empty = latest offset).
+//
+// replayWindow examples: "7d", "24h", "10m" — a value matching the backend
+// regex `(\d+)([smhd])` (python-be-streamkap
+// `app/utils/api/v2/api_transforms_utils.py:352`). The provider's resource
+// schema also documents "0" as "continue from last position"; that has the
+// same semantic as the empty string on the backend (both leave the deployer's
+// `start_time` as `None` → use latest offset) but the backend's regex rejects
+// "0" with a 400. Treat both as the no-replay case here so user configs that
+// rely on the documented "0" keep working.
 func (s *streamkapAPI) DeployTransformPreview(ctx context.Context, transformID, versionID, replayWindow string) error {
 	reqURL := s.cfg.BaseURL + "/transforms/" + transformID + "/deploy-job-preview/" + versionID
-	if replayWindow != "" {
+	if replayWindow != "" && replayWindow != "0" {
 		reqURL += "?replay_window=" + url.QueryEscape(replayWindow)
 	}
 

--- a/internal/provider/error_handling_test.go
+++ b/internal/provider/error_handling_test.go
@@ -217,6 +217,75 @@ func TestAPIError401_DeleteTransform(t *testing.T) {
 	assert.Contains(t, err.Error(), "Unauthorized")
 }
 
+// TestAPIError_NonJSONErrorBody_SurfacesStatusAndBody covers the gateway/
+// proxy failure mode: an upstream (nginx, load balancer, ingress) returns
+// HTML or a non-JSON body for a 5xx — historically the JSON decoder failed
+// silently and the provider surfaced a bare "invalid character '<' looking
+// for beginning of value" error with no status code and no body excerpt,
+// which dead-ended customer debugging. The error now includes the HTTP
+// status and a truncated body snippet so customers can see what the gateway
+// actually returned.
+func TestAPIError_NonJSONErrorBody_SurfacesStatusAndBody(t *testing.T) {
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	baseURL := "https://api.test.streamkap.com"
+	client := newTestAPIClient(baseURL)
+
+	const htmlBody = `<html><head><title>502 Bad Gateway</title></head><body><h1>Bad Gateway</h1></body></html>`
+	httpmock.RegisterResponder(
+		http.MethodGet,
+		baseURL+"/sources/some-id?secret_returned=true",
+		func(req *http.Request) (*http.Response, error) {
+			resp := httpmock.NewStringResponse(http.StatusBadGateway, htmlBody)
+			resp.Header.Set("Content-Type", "text/html")
+			return resp, nil
+		},
+	)
+
+	ctx := context.Background()
+	result, err := client.GetSource(ctx, "some-id")
+
+	require.Error(t, err, "Non-JSON error body must surface as an error, not a silent success")
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "502", "Error must include the HTTP status code")
+	assert.Contains(t, err.Error(), "502 Bad Gateway", "Error must include a snippet of the actual body")
+	assert.NotContains(t, err.Error(), "invalid character",
+		"Bare JSON decode error must not leak through to the user")
+}
+
+// TestAPIError_JSONErrorBody_PreservesDetail confirms the happy-path
+// behavior still works after the snippet refactor: a well-formed JSON
+// error response surfaces `detail` verbatim (with the request_id appended
+// when present).
+func TestAPIError_JSONErrorBody_PreservesDetail(t *testing.T) {
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	baseURL := "https://api.test.streamkap.com"
+	client := newTestAPIClient(baseURL)
+
+	httpmock.RegisterResponder(
+		http.MethodGet,
+		baseURL+"/sources/some-id?secret_returned=true",
+		func(req *http.Request) (*http.Response, error) {
+			resp, _ := httpmock.NewJsonResponse(http.StatusUnprocessableEntity, api.APIErrorResponse{
+				Detail: "Validation error: something is wrong with the request",
+			})
+			resp.Header.Set("X-Request-Id", "req-123-abc")
+			return resp, nil
+		},
+	)
+
+	ctx := context.Background()
+	result, err := client.GetSource(ctx, "some-id")
+
+	require.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "Validation error: something is wrong with the request")
+	assert.Contains(t, err.Error(), "req-123-abc", "request_id must be appended when present")
+}
+
 // =============================================================================
 // 404 Not Found Error Tests
 // =============================================================================
@@ -830,13 +899,19 @@ func TestListTransforms_Paginates(t *testing.T) {
 	assert.Equal(t, "t-page2-4", result[104].ID)
 }
 
-// TestAPIError422_TransformDuplicateName is a regression test for issue #75:
-// when a transform with the same name already exists, the create path must
-// adopt it. The transform name lives in Config["transforms.name"] (backend
-// alias), not Config["name"], so the adopt lookup previously searched for an
-// empty string and surfaced "transform \"\" reported as existing but not
-// found in list".
-func TestAPIError422_TransformDuplicateName(t *testing.T) {
+// TestAPIError422_TransformDuplicateName_FailsWithRecoveryGuidance is the
+// counterpart of TestAPIError409_PipelineDuplicateName_FailsWithRecoveryGuidance
+// for transforms. Same root cause: auto-adopting on a name conflict is unsafe
+// under `lifecycle { create_before_destroy = true }` because the deposed
+// state entry and the freshly-created live entry would share the same backend
+// id; the next destroy of the deposed would DELETE the live transform.
+//
+// The customer's debug log (0_Terraform Apply.txt) showed deposed transform
+// entries (e.g. `transform_sql_join.live[0] (destroy deposed cd669fa8)`)
+// alongside the deposed pipeline entries, so the same pattern would have
+// bitten them in transforms once the pipeline path was unblocked. Prevent
+// that by failing loudly with the same recovery guidance.
+func TestAPIError422_TransformDuplicateName_FailsWithRecoveryGuidance(t *testing.T) {
 	httpmock.Activate()
 	defer httpmock.DeactivateAndReset()
 
@@ -851,89 +926,122 @@ func TestAPIError422_TransformDuplicateName(t *testing.T) {
 		},
 	}
 
+	postCalls := 0
 	httpmock.RegisterResponder(
 		http.MethodPost,
 		baseURL+"/transforms?secret_returned=true",
 		func(req *http.Request) (*http.Response, error) {
-			errResponse := api.APIErrorResponse{
+			postCalls++
+			return httpmock.NewJsonResponse(http.StatusUnprocessableEntity, api.APIErrorResponse{
 				Detail: "A transform with name 'existing-transform' already exists",
-			}
-			return httpmock.NewJsonResponse(http.StatusUnprocessableEntity, errResponse)
+			})
 		},
 	)
 
-	// Mock the paginated partial_name-filtered list-for-adopt follow-up.
+	// Same guard as the pipeline test: MUST NOT call the list endpoint to
+	// auto-adopt. A future refactor that re-introduces adoption will trip
+	// this assertion.
+	adoptCalls := 0
 	httpmock.RegisterResponder(
 		http.MethodGet,
 		baseURL+"/transforms?secret_returned=true&page=1&page_size=100&partial_name=existing-transform",
 		func(req *http.Request) (*http.Response, error) {
-			return httpmock.NewJsonResponse(http.StatusOK, api.GetTransformResponse{
-				Total: 1,
-				Result: []api.Transform{
-					{ID: "adopted-transform-id", Name: "existing-transform", TransformType: "sql_join"},
-				},
-			})
+			adoptCalls++
+			return httpmock.NewStringResponse(http.StatusOK, `{}`), nil
 		},
 	)
 
 	ctx := context.Background()
 	result, err := client.CreateTransform(ctx, transform)
 
-	require.NoError(t, err, "Duplicate name should trigger adoption, not an error")
-	require.NotNil(t, result, "Adopted transform should be returned")
-	assert.Equal(t, "adopted-transform-id", result.ID, "Should return the existing transform's ID")
-	assert.Equal(t, "existing-transform", result.Name)
+	require.Error(t, err, "Duplicate name must surface as an error, never auto-adopt")
+	assert.Nil(t, result)
+	assert.Equal(t, 1, postCalls, "POST should be attempted exactly once")
+	assert.Equal(t, 0, adoptCalls, "MUST NOT call the list endpoint to auto-adopt on duplicate-name conflict")
+
+	errMsg := err.Error()
+	assert.Contains(t, errMsg, "existing-transform")
+	assert.Contains(t, errMsg, "create_before_destroy",
+		"error must mention the lifecycle-incompatibility recovery path")
+	assert.Contains(t, errMsg, "terraform import",
+		"error must mention the import-based recovery path")
+	assert.Contains(t, errMsg, "already exists",
+		"original backend detail must be preserved for diagnostics")
 }
 
-// TestAPIError422_TransformDuplicateName_AdoptNotFound covers the path where
-// the backend reports "already exists" but the list endpoint can't locate the
-// transform (e.g. orphan in a different service of the same tenant). The
-// original error must be preserved so the user sees something actionable.
-func TestAPIError422_TransformDuplicateName_AdoptNotFound(t *testing.T) {
+// TestAPIError409_PipelineDuplicateName_FailsWithRecoveryGuidance is a
+// regression test for the customer scenario reported in 0_Terraform Apply.txt.
+//
+// Background: pipelines have a {tenant_id, service_id, name} uniqueness
+// constraint at the backend, so a `lifecycle { create_before_destroy = true }`
+// replace can't work — the deposed instance and the new instance would need
+// to coexist by name, and the backend refuses. An earlier attempt at a
+// "smart" recovery was to look the existing pipeline up by name and either
+// return it as-is (loses the user's planned config) or PUT the planned
+// payload onto it (worse — succeeds the Create step, then Terraform's destroy
+// of the deposed entry DELETEs the same backend id the live state was just
+// pointed to, silently destroying the customer's live pipeline).
+//
+// The safe behavior — and what this test asserts — is to refuse adoption
+// entirely on 409 and surface a clear error explaining the two recovery
+// paths (remove create_before_destroy, or `terraform import` the existing
+// pipeline). Loud failure beats silent data loss.
+func TestAPIError409_PipelineDuplicateName_FailsWithRecoveryGuidance(t *testing.T) {
 	httpmock.Activate()
 	defer httpmock.DeactivateAndReset()
 
 	baseURL := "https://api.test.streamkap.com"
 	client := newTestAPIClient(baseURL)
 
-	transform := api.CreateTransformRequest{
-		Transform: "sql_join",
-		Config: map[string]any{
-			"transforms.name":     "orphan-transform",
-			"transforms.language": "SQL",
-		},
+	plannedPipeline := api.Pipeline{
+		Name:        "Pipeline_test_live",
+		Source:      api.PipelineSource{ID: "src-x", Name: "src-x", Connector: "dynamodb"},
+		Destination: api.PipelineDestination{ID: "dst-x", Name: "dst-x", Connector: "postgresql"},
 	}
 
+	postCalls := 0
 	httpmock.RegisterResponder(
 		http.MethodPost,
-		baseURL+"/transforms?secret_returned=true",
+		baseURL+"/pipelines?secret_returned=true&wait=false",
 		func(req *http.Request) (*http.Response, error) {
-			errResponse := api.APIErrorResponse{
-				Detail: "A transform with name 'orphan-transform' already exists",
-			}
-			return httpmock.NewJsonResponse(http.StatusUnprocessableEntity, errResponse)
-		},
-	)
-
-	// List endpoint returns zero results — the adopt lookup cannot locate it.
-	httpmock.RegisterResponder(
-		http.MethodGet,
-		baseURL+"/transforms?secret_returned=true&page=1&page_size=100&partial_name=orphan-transform",
-		func(req *http.Request) (*http.Response, error) {
-			return httpmock.NewJsonResponse(http.StatusOK, api.GetTransformResponse{
-				Total:  0,
-				Result: []api.Transform{},
+			postCalls++
+			return httpmock.NewJsonResponse(http.StatusConflict, api.APIErrorResponse{
+				Detail: "A pipeline with name 'Pipeline_test_live' already exists",
 			})
 		},
 	)
 
-	ctx := context.Background()
-	result, err := client.CreateTransform(ctx, transform)
+	// We must NOT issue a GET to /pipelines for adoption. Register a
+	// responder that fails the test if hit so a future refactor that
+	// accidentally re-introduces adoption will be caught here.
+	adoptCalls := 0
+	httpmock.RegisterResponder(
+		http.MethodGet,
+		baseURL+"/pipelines?secret_returned=true&page=1&page_size=100&partial_name=Pipeline_test_live",
+		func(req *http.Request) (*http.Response, error) {
+			adoptCalls++
+			return httpmock.NewStringResponse(http.StatusOK, `{}`), nil
+		},
+	)
 
-	require.Error(t, err, "Expected error when adopt lookup fails")
-	assert.Nil(t, result, "Result should be nil when adopt fails")
-	assert.Contains(t, err.Error(), "already exists", "Original error must be preserved")
-	assert.Contains(t, err.Error(), "could not locate it via the list endpoint", "Should explain the adopt failure")
+	ctx := context.Background()
+	result, err := client.CreatePipeline(ctx, plannedPipeline)
+
+	require.Error(t, err, "409 on POST /pipelines must surface as an error, never auto-adopt")
+	assert.Nil(t, result)
+	assert.Equal(t, 1, postCalls, "POST should be attempted exactly once")
+	assert.Equal(t, 0, adoptCalls, "MUST NOT call the list endpoint to auto-adopt on 409")
+
+	// The error message must be actionable — point the user at both
+	// recovery paths.
+	errMsg := err.Error()
+	assert.Contains(t, errMsg, "Pipeline_test_live")
+	assert.Contains(t, errMsg, "create_before_destroy",
+		"error must mention the lifecycle-incompatibility recovery path")
+	assert.Contains(t, errMsg, "terraform import",
+		"error must mention the import-based recovery path")
+	assert.Contains(t, errMsg, "already exists",
+		"original backend detail must be preserved for diagnostics")
 }
 
 // TestAPIError422_TransformInvalidConfig tests 422 for transform-specific validation

--- a/internal/provider/migration_test.go
+++ b/internal/provider/migration_test.go
@@ -172,104 +172,24 @@ resource "streamkap_destination_snowflake" "migration_test" {
 	})
 }
 
+// TestAccPipeline_MigrationFromLegacy is intentionally skipped.
+//
+// v3's pipeline schema is a breaking change from v2: `source_id` /
+// `destination_id` were replaced with nested `source { id name connector
+// topics }` and `destination { id name connector }` blocks. A single shared
+// HCL config can't satisfy both providers, so Step 1 (v2.1.18 provider) and
+// Step 2 (v3 provider) require different configs — neither of which the
+// sibling source/destination migration tests have to deal with, because
+// their schemas stayed compatible across versions.
+//
+// A real migration test for this resource needs two configs and an
+// `ExpectEmptyPlan` that survives the state-shape rewrite. Until that
+// is written, skip rather than leave a perpetually-red signal.
+//
+// Cross-reference: docs/MIGRATION.md → "Known limitations".
 func TestAccPipeline_MigrationFromLegacy(t *testing.T) {
-	// Pipeline Migration Strategy:
-	// Pipelines have dependencies on source and destination connectors.
-	// We test pipeline migration in a single test that:
-	// 1. Creates source + destination + pipeline with OLD provider
-	// 2. Switches to NEW provider and verifies empty plan for ALL resources
-	//
-	// This ensures the entire resource graph migrates correctly.
-
-	// Get required env vars for skip check
-	// Note: All other vars are passed via TF_VAR_* env vars to terraform
-	pgHostname := os.Getenv("TF_VAR_source_postgresql_hostname")
-	sfURL := os.Getenv("TF_VAR_destination_snowflake_url_name")
-
-	if pgHostname == "" || sfURL == "" {
-		t.Skip("Pipeline migration requires both source and destination env vars")
-	}
-
-	config := providerConfig + `
-variable "source_postgresql_hostname" { type = string }
-variable "source_postgresql_password" {
-  type      = string
-  sensitive = true
-}
-variable "destination_snowflake_url_name" { type = string }
-variable "destination_snowflake_user_name" { type = string }
-variable "destination_snowflake_private_key" {
-  type      = string
-  sensitive = true
-}
-variable "destination_snowflake_private_key_passphrase" {
-  type      = string
-  sensitive = true
-  default   = ""
-}
-variable "destination_snowflake_database_name" { type = string }
-variable "destination_snowflake_schema_name" { type = string }
-
-resource "streamkap_source_postgresql" "pipeline_test" {
-	name                                         = "tf-migration-pipeline-source"
-	database_hostname                            = var.source_postgresql_hostname
-	database_port                                = "5432"
-	database_user                                = "postgresql"
-	database_password                            = var.source_postgresql_password
-	database_dbname                              = "postgres"
-	database_sslmode                             = "require"
-	schema_include_list                          = "streamkap"
-	table_include_list                           = "streamkap.customer"
-	signal_data_collection_schema_or_database    = "streamkap"
-	heartbeat_data_collection_schema_or_database = "streamkap"
-	slot_name                                    = "tf_pipeline_slot"
-	publication_name                             = "tf_pipeline_pub"
-	ssh_enabled                                  = false
-}
-
-resource "streamkap_destination_snowflake" "pipeline_test" {
-	name                             = "tf-migration-pipeline-dest"
-	snowflake_url_name               = var.destination_snowflake_url_name
-	snowflake_user_name              = var.destination_snowflake_user_name
-	snowflake_private_key            = var.destination_snowflake_private_key
-	snowflake_private_key_passphrase = var.destination_snowflake_private_key_passphrase
-	snowflake_database_name          = var.destination_snowflake_database_name
-	snowflake_schema_name            = var.destination_snowflake_schema_name
-}
-
-resource "streamkap_pipeline" "pipeline_test" {
-	name           = "tf-migration-pipeline"
-	source_id      = streamkap_source_postgresql.pipeline_test.id
-	destination_id = streamkap_destination_snowflake.pipeline_test.id
-	# Note: Add snapshot_new_tables and other optional fields as needed
-}
-`
-
-	resource.Test(t, resource.TestCase{
-		Steps: []resource.TestStep{
-			// Step 1: Create entire graph with OLD provider
-			{
-				ExternalProviders: legacyProviderConfig(),
-				Config:            config,
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("streamkap_source_postgresql.pipeline_test", "name", "tf-migration-pipeline-source"),
-					resource.TestCheckResourceAttr("streamkap_destination_snowflake.pipeline_test", "name", "tf-migration-pipeline-dest"),
-					resource.TestCheckResourceAttr("streamkap_pipeline.pipeline_test", "name", "tf-migration-pipeline"),
-					resource.TestCheckResourceAttrSet("streamkap_pipeline.pipeline_test", "id"),
-				),
-			},
-			// Step 2: Switch to NEW provider - ALL resources must produce empty plan
-			{
-				ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-				Config:                   config,
-				ConfigPlanChecks: resource.ConfigPlanChecks{
-					PreApply: []plancheck.PlanCheck{
-						plancheck.ExpectEmptyPlan(),
-					},
-				},
-			},
-		},
-	})
+	t.Skip("v3 pipeline source/destination schema is a breaking change from v2; " +
+		"this test needs separate v2 and v3 configs (see comment header)")
 }
 
 // ============================================================================

--- a/internal/provider/topic_resource_test.go
+++ b/internal/provider/topic_resource_test.go
@@ -6,7 +6,37 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
+// TestAccTopicResource exercises create → update → delete on streamkap_topic.
+//
+// This test is currently self-poisoning: Step 1 creates the topic with 25
+// partitions, Step 3 updates to 26. Kafka partition counts can only
+// increase, so the second run sees the topic at 26 already and Step 1
+// (which sets 25) fails with "New partition count (25) must be greater
+// than the current count (26)".
+//
+// The backend's DELETE /topics/{id} only removes the streamkap DB record;
+// the underlying Kafka topic survives at whatever count the previous run
+// left it. We confirmed this by adding a PreConfig that calls
+// client.DeleteTopic — the streamkap-side delete returns "Could not find
+// the topic" while the Kafka topic still reports 26 partitions on the
+// next streamkap_topic create.
+//
+// Fixing this properly requires either:
+//   - direct Kafka admin access from the test (out of scope; tests run
+//     against api.streamkap.com via HTTPS only), or
+//   - reworking the test to discover the live partition count and write
+//     Step 1/3 configs dynamically (Config is static HCL via
+//     terraform-plugin-testing, so this would need PreConfig + a
+//     templated config string).
+//
+// Until the backend exposes a way to reset a topic's Kafka partition
+// count, the test must be skipped to avoid a perpetual red signal that
+// has nothing to do with provider code.
 func TestAccTopicResource(t *testing.T) {
+	t.Skip("self-poisoning: Kafka partition counts can only increase, " +
+		"so each run leaves the fixture topic in a state that breaks " +
+		"the next run's Step 1 (see comment header for the fix paths)")
+
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		CheckDestroy:             testAccCheckTopicDestroy,


### PR DESCRIPTION
## Summary

A customer reported `Provider produced inconsistent result after apply` on `streamkap_pipeline.transforms[].topics` (full debug log: 0_Terraform Apply.txt, since cleaned up). Root-cause investigation revealed that the underlying bug is **silent data loss** — the previous adopt-on-conflict behavior under `lifecycle { create_before_destroy = true }` would have destroyed the customer's live pipeline once the apply got unstuck. This PR removes the unsafe behavior, surfaces a clear actionable error, and documents the recovery workflow.

## What's broken (before this PR)

When `POST /pipelines` returned 409 "already exists" (happens under `create_before_destroy` because the deposed instance still occupies the `{tenant_id, service_id, name}` slot), the provider:
1. Looked up the existing pipeline by name → returned it from `Create`.
2. Live state ends up with the same backend id as the deposed entry.
3. Terraform proceeds to "destroy deposed" → `DELETE /pipelines/{shared_id}`.
4. The backend pipeline (which `live` references) is deleted.
5. Customer's pipeline is gone.

The customer had **4 deposed pipeline entries + several deposed transform entries** in state, all pointing at the same backend records — they would have lost data on first successful apply. Same bug exists in `streamkap_transform_*`.

## What changes

- **`internal/api/pipeline.go`, `internal/api/transform.go`**: Refuse to auto-adopt on name conflict. Surface a clear error with three recovery paths (remove `create_before_destroy`, clean up deposed entries with `terraform state rm`, or `terraform import` the existing record).
- **`internal/api/client.go`**: Non-JSON error responses (HTML from nginx/ingress 5xx) now surface the HTTP status and a body snippet instead of the bare `invalid character '<'` JSON-decode error.
- **`internal/api/transform.go`**: `replay_window = "0"` (documented as "continue from last position") now translates to omitting the query parameter — the backend regex rejects bare `"0"`; both `"0"` and `""` map to `start_time = None` semantically.
- **`internal/provider/migration_test.go`**: `TestAccPipeline_MigrationFromLegacy` skips cleanly (v3's pipeline source/destination schema is a breaking change from v2; needs separate v2/v3 configs that aren't yet written).
- **`internal/provider/topic_resource_test.go`**: `TestAccTopicResource` skips cleanly with documented reason (Kafka partition counts only grow + backend topic DELETE only removes the streamkap DB record, not the Kafka topic).
- **`docs/MIGRATION.md`**: New "Known limitations" section documenting the create_before_destroy incompatibility and recovery workflow.
- **`CHANGELOG.md`**: Entry under [Unreleased] with the full reasoning.

## Backend verification

The fix was audited end-to-end against `python-be-streamkap` source code by a parallel subagent. All 7 round-trip points (409 trigger location and error wording, PUT full-replace semantics for transforms, `get_pretty_topic_name_from_id` reconstruction, `get_topic_id_from_pretty_name` synthesis, name uniqueness scope, `wait=false` response shape, 409 vs 422 codes) were confirmed match the provider's assumptions.

A second audit pass covered eight remaining pipeline drift risks (transforms list ordering, interleaved IDs, empty transforms, `snapshot_new_tables` defaults, source/destination round-trip, tag empty-vs-default, read-order stability, `Source.Topics` computed-vs-required) — all confirmed safe in the current backend.

## Why not "compare configs, only adopt if match"

I considered a smarter variant that compares the planned config to the adopted record and only adopts when they match. **It's still unsafe** — the `terraform taint + create_before_destroy + no config change` edge case collapses to the same data-loss scenario (configs match → adopt → live and deposed share an id → destroy nukes the pipeline). The only safe option from inside an API client (no state visibility) is to refuse adoption entirely.

## Why not also fix source/destination/tag adoption

Same theoretical risk exists for those resources. Held back because (a) customer wasn't hitting it on those resources, (b) existing acceptance tests rely on adopt-on-422 there, and (c) tightening would break legitimate timed-out-create recovery workflows. Documented in CHANGELOG as a follow-up. This is **not** a statement that they are safe; track removing their adopt path before any customer relies on `create_before_destroy` against those resources.

## Customer recovery workflow

After upgrading, the customer's first apply will FAIL on the new error (because their state still has 4+ deposed entries pointing at the same backend record). The error message walks them through:
1. `terraform state rm '<resource_address>'` for each accumulated deposed entry.
2. `terraform import streamkap_pipeline.<name> <pipeline_id>` to bring the existing pipeline back in as live.
3. Remove `lifecycle { create_before_destroy = true }` from the pipeline going forward.
4. `terraform apply` — now an Update, succeeds.

After step 3 they won't hit this class of bug again. **No data loss path.**

## Test plan

- [x] `go build ./...` clean
- [x] `gofmt -l .` clean
- [x] `go vet ./...` clean
- [x] New regression tests pass: `TestAPIError409_PipelineDuplicateName_FailsWithRecoveryGuidance`, `TestAPIError422_TransformDuplicateName_FailsWithRecoveryGuidance`, `TestAPIError_NonJSONErrorBody_SurfacesStatusAndBody`, `TestAPIError_JSONErrorBody_PreservesDetail`
- [x] All `TestAPIError*`, `TestPipelineTransforms*`, `TestSchemaBackwardsCompatibility*`, validator tests green
- [x] `TestAccTransformSqlJoinResource_withImplementation` PASS (9.24s) — previously failed with `invalid character '<'`, now passes with improved error handling
- [x] `TestAccTransformMapFilterResource_deployWithReplayWindow` PASS (84.53s) — previously failed with backend rejecting `"0"`, now passes with the translation fix
- [x] `TestAccTopicResource` SKIPS cleanly with documented reason
- [x] `TestAccPipeline_MigrationFromLegacy` SKIPS cleanly with documented reason
- [ ] Customer to verify the recovery workflow against their state after upgrade

## Reviewer notes

Final code review was completed before opening this PR (superpowers:code-reviewer subagent). All Important issues were addressed in the final commit before push:
- Error messages now include the `terraform state rm` step for accumulated deposed entries.
- CHANGELOG reasoning for the source/destination/tag hold-back was clarified — the risk is real, not "safe by some property of those resources".
- MIGRATION.md disambiguates `streamkap_transform_<type>` for the import command (matches the existing record's `transform` field).

🤖 Generated with [Claude Code](https://claude.com/claude-code)