### PR TITLE
[v2] fix: provider robustness on read and error paths (ENG-2460, ENG-2461)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,5 @@ FEATURES:
 BUG FIXES:
 
 * **Provider error handling**: API errors that return a non-JSON body (gateway HTML pages, WAF blocks, proxy 5xx) now surface as `unexpected <status> <status text> from <method> <url>: <body snippet>` instead of the cryptic `invalid character '<' looking for beginning of value`. The HTTP status, URL, and a truncated body snippet are included directly in the Terraform error, so failures like 504 gateway timeouts on long-running operations are diagnosable without re-running with `TF_LOG=DEBUG`. Resolves ENG-2460.
+
+* **Resource read**: When a resource (source, destination, pipeline) is deleted out-of-band — for example via the Streamkap UI, ops cleanup, or a prior failed `terraform destroy` — the `Read` handler now removes it from Terraform state instead of returning `... does not exist`. `terraform refresh` / `terraform plan` recover automatically and propose recreating the resource; previously the only workaround was `terraform state rm`. Resolves ENG-2461.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
 ## 0.1.0 (Unreleased)
 
 FEATURES:
+
+BUG FIXES:
+
+* **Provider error handling**: API errors that return a non-JSON body (gateway HTML pages, WAF blocks, proxy 5xx) now surface as `unexpected <status> <status text> from <method> <url>: <body snippet>` instead of the cryptic `invalid character '<' looking for beginning of value`. The HTTP status, URL, and a truncated body snippet are included directly in the Terraform error, so failures like 504 gateway timeouts on long-running operations are diagnosable without re-running with `TF_LOG=DEBUG`. Resolves ENG-2460.

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -86,6 +86,12 @@ func (s *streamkapAPI) doRequest(ctx context.Context, req *http.Request, result 
 	}
 	defer resp.Body.Close()
 
+	requestID := resp.Header.Get("X-Request-Id")
+	if requestID != "" {
+		tflog.Debug(ctx, fmt.Sprintf("%s %s returned %d (request_id=%s)",
+			req.Method, req.URL, resp.StatusCode, requestID))
+	}
+
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("%s %s: failed to read response body (status %d): %w",
@@ -95,19 +101,22 @@ func (s *streamkapAPI) doRequest(ctx context.Context, req *http.Request, result 
 	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
 		var apiErr APIErrorResponse
 		if jsonErr := json.Unmarshal(body, &apiErr); jsonErr == nil && apiErr.Detail != "" {
-			return errors.New(apiErr.Detail)
+			return errors.New(withRequestID(apiErr.Detail, requestID))
 		}
 		tflog.Debug(ctx,
 			fmt.Sprintf("%s %s returned %d with non-JSON or empty error body",
 				req.Method, req.URL, resp.StatusCode),
 		)
-		return fmt.Errorf("unexpected %d %s from %s %s: %s",
-			resp.StatusCode,
-			http.StatusText(resp.StatusCode),
-			req.Method,
-			req.URL,
-			truncateBody(body, errorBodySnippetLimit),
-		)
+		return errors.New(withRequestID(
+			fmt.Sprintf("unexpected %d %s from %s %s: %s",
+				resp.StatusCode,
+				http.StatusText(resp.StatusCode),
+				req.Method,
+				req.URL,
+				truncateBody(body, errorBodySnippetLimit),
+			),
+			requestID,
+		))
 	}
 
 	if err := json.Unmarshal(body, result); err != nil {
@@ -118,8 +127,20 @@ func (s *streamkapAPI) doRequest(ctx context.Context, req *http.Request, result 
 
 func truncateBody(body []byte, limit int) string {
 	s := strings.TrimSpace(string(body))
+	s = strings.ReplaceAll(s, "\n", " ")
+	s = strings.ReplaceAll(s, "\r", " ")
+	if s == "" {
+		return "(empty body)"
+	}
 	if len(s) <= limit {
 		return s
 	}
 	return s[:limit] + "...(truncated)"
+}
+
+func withRequestID(msg, requestID string) string {
+	if requestID == "" {
+		return msg
+	}
+	return fmt.Sprintf("%s (request_id=%s)", msg, requestID)
 }

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -5,10 +5,14 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
+
+const errorBodySnippetLimit = 512
 
 type StreamkapAPI interface {
 	GetAccessToken(clientID, secret string) (*Token, error)
@@ -80,29 +84,42 @@ func (s *streamkapAPI) doRequest(ctx context.Context, req *http.Request, result 
 	if err != nil {
 		return err
 	}
-
 	defer resp.Body.Close()
 
-	respBodyDecoder := json.NewDecoder(resp.Body)
-	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
-		var apiErr APIErrorResponse
-		if err := respBodyDecoder.Decode(&apiErr); err != nil {
-			tflog.Debug(ctx,
-				fmt.Sprintf("%s request to %s got status code: %d. Failed to parse API error response: %v",
-					req.Method,
-					req.URL,
-					resp.StatusCode,
-					err,
-				),
-			)
-			return err
-		} else {
-			return errors.New(apiErr.Detail)
-		}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("%s %s: failed to read response body (status %d): %w",
+			req.Method, req.URL, resp.StatusCode, err)
 	}
 
-	if err := respBodyDecoder.Decode(result); err != nil {
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		var apiErr APIErrorResponse
+		if jsonErr := json.Unmarshal(body, &apiErr); jsonErr == nil && apiErr.Detail != "" {
+			return errors.New(apiErr.Detail)
+		}
+		tflog.Debug(ctx,
+			fmt.Sprintf("%s %s returned %d with non-JSON or empty error body",
+				req.Method, req.URL, resp.StatusCode),
+		)
+		return fmt.Errorf("unexpected %d %s from %s %s: %s",
+			resp.StatusCode,
+			http.StatusText(resp.StatusCode),
+			req.Method,
+			req.URL,
+			truncateBody(body, errorBodySnippetLimit),
+		)
+	}
+
+	if err := json.Unmarshal(body, result); err != nil {
 		return err
 	}
 	return nil
+}
+
+func truncateBody(body []byte, limit int) string {
+	s := strings.TrimSpace(string(body))
+	if len(s) <= limit {
+		return s
+	}
+	return s[:limit] + "...(truncated)"
 }

--- a/internal/resource/destination/clickhouse.go
+++ b/internal/resource/destination/clickhouse.go
@@ -280,10 +280,7 @@ func (r *DestinationClickHouseResource) Read(ctx context.Context, req res.ReadRe
 		return
 	}
 	if destination == nil {
-		resp.Diagnostics.AddError(
-			"Error reading ClickHouse destination",
-			fmt.Sprintf("ClickHouse destination %s does not exist", destinationID),
-		)
+		resp.State.RemoveResource(ctx)
 		return
 	}
 

--- a/internal/resource/destination/databricks.go
+++ b/internal/resource/destination/databricks.go
@@ -267,10 +267,7 @@ func (r *DestinationDatabricksResource) Read(ctx context.Context, req res.ReadRe
 		return
 	}
 	if destination == nil {
-		resp.Diagnostics.AddError(
-			"Error reading Databricks destination",
-			fmt.Sprintf("Databricks destination %s does not exist", destinationID),
-		)
+		resp.State.RemoveResource(ctx)
 		return
 	}
 

--- a/internal/resource/destination/iceberg.go
+++ b/internal/resource/destination/iceberg.go
@@ -270,10 +270,7 @@ func (r *DestinationIcebergResource) Read(ctx context.Context, req res.ReadReque
 		return
 	}
 	if destination == nil {
-		resp.Diagnostics.AddError(
-			"Error reading Iceberg destination",
-			fmt.Sprintf("Iceberg destination %s does not exist", destinationID),
-		)
+		resp.State.RemoveResource(ctx)
 		return
 	}
 

--- a/internal/resource/destination/kafka.go
+++ b/internal/resource/destination/kafka.go
@@ -225,10 +225,7 @@ func (r *DestinationKafkaResource) Read(ctx context.Context, req res.ReadRequest
 		return
 	}
 	if destination == nil {
-		resp.Diagnostics.AddError(
-			"Error reading Kafka destination",
-			fmt.Sprintf("Kafka destination %s does not exist", destinationID),
-		)
+		resp.State.RemoveResource(ctx)
 		return
 	}
 

--- a/internal/resource/destination/postgresql.go
+++ b/internal/resource/destination/postgresql.go
@@ -304,10 +304,7 @@ func (r *DestinationPostgresqlResource) Read(ctx context.Context, req res.ReadRe
 		return
 	}
 	if destination == nil {
-		resp.Diagnostics.AddError(
-			"Error reading Postgresql destination",
-			fmt.Sprintf("Postgresql destination %s does not exist", destinationID),
-		)
+		resp.State.RemoveResource(ctx)
 		return
 	}
 

--- a/internal/resource/destination/s3.go
+++ b/internal/resource/destination/s3.go
@@ -277,10 +277,7 @@ func (r *DestinationS3Resource) Read(ctx context.Context, req res.ReadRequest, r
 		return
 	}
 	if destination == nil {
-		resp.Diagnostics.AddError(
-			"Error reading S3 destination",
-			fmt.Sprintf("S3 destination %s does not exist", destinationID),
-		)
+		resp.State.RemoveResource(ctx)
 		return
 	}
 

--- a/internal/resource/destination/snowflake.go
+++ b/internal/resource/destination/snowflake.go
@@ -338,10 +338,7 @@ func (r *DestinationSnowflakeResource) Read(ctx context.Context, req res.ReadReq
 		return
 	}
 	if destination == nil {
-		resp.Diagnostics.AddError(
-			"Error reading Snowflake destination",
-			fmt.Sprintf("Snowflake destination %s does not exist", destinationID),
-		)
+		resp.State.RemoveResource(ctx)
 		return
 	}
 

--- a/internal/resource/pipeline/pipeline.go
+++ b/internal/resource/pipeline/pipeline.go
@@ -261,10 +261,7 @@ func (r *PipelineResource) Read(ctx context.Context, req res.ReadRequest, resp *
 		return
 	}
 	if pipeline == nil {
-		resp.Diagnostics.AddError(
-			"Error reading pipeline",
-			fmt.Sprintf("Pipeline %s does not exist", pipelineID),
-		)
+		resp.State.RemoveResource(ctx)
 		return
 	}
 

--- a/internal/resource/source/dynamodb.go
+++ b/internal/resource/source/dynamodb.go
@@ -265,10 +265,7 @@ func (r *SourceDynamoDBResource) Read(ctx context.Context, req res.ReadRequest, 
 		return
 	}
 	if source == nil {
-		resp.Diagnostics.AddError(
-			"Error reading DynamoDB source",
-			fmt.Sprintf("DynamoDB source %s does not exist", sourceID),
-		)
+		resp.State.RemoveResource(ctx)
 		return
 	}
 

--- a/internal/resource/source/kafkadirect.go
+++ b/internal/resource/source/kafkadirect.go
@@ -188,10 +188,7 @@ func (r *SourceKafkaDirectResource) Read(ctx context.Context, req res.ReadReques
 		return
 	}
 	if source == nil {
-		resp.Diagnostics.AddError(
-			"Error reading Kafka Direct source",
-			fmt.Sprintf("Kafka Direct source %s does not exist", sourceID),
-		)
+		resp.State.RemoveResource(ctx)
 		return
 	}
 

--- a/internal/resource/source/mongodb.go
+++ b/internal/resource/source/mongodb.go
@@ -292,10 +292,7 @@ func (r *SourceMongoDBResource) Read(ctx context.Context, req res.ReadRequest, r
 		return
 	}
 	if source == nil {
-		resp.Diagnostics.AddError(
-			"Error reading MongoDB source",
-			fmt.Sprintf("MongoDB source %s does not exist", sourceID),
-		)
+		resp.State.RemoveResource(ctx)
 		return
 	}
 

--- a/internal/resource/source/mysql.go
+++ b/internal/resource/source/mysql.go
@@ -441,10 +441,7 @@ func (r *SourceMySQLResource) Read(ctx context.Context, req res.ReadRequest, res
 		return
 	}
 	if source == nil {
-		resp.Diagnostics.AddError(
-			"Error reading MySQL source",
-			fmt.Sprintf("MySQL source %s does not exist", sourceID),
-		)
+		resp.State.RemoveResource(ctx)
 		return
 	}
 

--- a/internal/resource/source/postgresql.go
+++ b/internal/resource/source/postgresql.go
@@ -402,10 +402,7 @@ func (r *SourcePostgreSQLResource) Read(ctx context.Context, req res.ReadRequest
 		return
 	}
 	if source == nil {
-		resp.Diagnostics.AddError(
-			"Error reading PostgreSQL source",
-			fmt.Sprintf("PostgreSQL source %s does not exist", sourceID),
-		)
+		resp.State.RemoveResource(ctx)
 		return
 	}
 

--- a/internal/resource/source/sqlserver.go
+++ b/internal/resource/source/sqlserver.go
@@ -349,10 +349,7 @@ func (r *SourceSQLServerResource) Read(ctx context.Context, req res.ReadRequest,
 		return
 	}
 	if source == nil {
-		resp.Diagnostics.AddError(
-			"Error reading SQLServer source",
-			fmt.Sprintf("SQLServer source %s does not exist", sourceID),
-		)
+		resp.State.RemoveResource(ctx)
 		return
 	}
 


### PR DESCRIPTION
**Target:** v2 (`main`)

### ENG-2460 — surface HTTP status + body on non-JSON error responses

`internal/api/client.go`: when the API returns a non-JSON error body (gateway HTML, WAF page, proxy 5xx), return an error containing method + URL + status + status text + truncated body, instead of the raw JSON decoder error. Failures like 504 gateway timeouts now surface as `unexpected 504 Gateway Timeout from DELETE /sources/{id}: <html>...` instead of `invalid character '<' looking for beginning of value`. JSON `APIErrorResponse.Detail` path is unchanged.

`X-Request-Id` from the response is also captured: logged at Debug for every response, and appended as `(request_id=...)` to both error paths so support can join provider errors to backend logs.

### ENG-2461 — Read clears state when API returns nil

Across 14 source / destination / pipeline `Read` methods, replace the `AddError("... does not exist")` block with `resp.State.RemoveResource(ctx)` so out-of-band deletion (UI cleanup, ops intervention, prior failed destroy) is recoverable via `terraform refresh` / `plan` without manual `terraform state rm`.

### Behaviour

- Error messages on non-JSON 4xx/5xx are now verbose: status, URL, body snippet (≤ 512 bytes), and `request_id` when present.
- `Read` on a missing resource removes it from state; the next plan proposes recreation.

### Upgrade steps (v2 users)

Patch-level change. No schema changes, no state migration, no required-attribute changes. Both fixes are backwards-compatible with existing configurations.

1. Once a new v2 patch release containing this PR is tagged, bump the `streamkap` provider version constraint in `required_providers`:
   ```hcl
   streamkap = {
     source  = "streamkap-com/streamkap"
     version = "~> 2.1"
   }
   ```
2. `terraform init -upgrade` to fetch the new provider.
3. `terraform plan` — any resource previously deleted out-of-band will be removed from state automatically and the plan will propose recreation. Apply if recreation is intended.

`terraform state rm <addr>` remains the manual escape hatch for the same scenario without upgrading.

No `go generate` — docs regen lands with the release that ships this fix.