### PR TITLE
test(ci): add webhook sources + topics datasource to curated acceptance set

### DIFF
--- a/scripts/acceptance-tests.txt
+++ b/scripts/acceptance-tests.txt
@@ -21,6 +21,9 @@ TestAccSourceMariaDBResource
 TestAccSourceOracleResource
 TestAccSourceOracleAWSResource
 TestAccSourceS3Resource
+TestAccSourceWebhookResource
+TestAccSourceShopifyWebhookResource
+TestAccSourceStripeWebhookResource
 
 # --- Destinations ---
 TestAccDestinationAzblobResource
@@ -42,6 +45,7 @@ TestAccDestinationStarburstResource
 # --- Data sources ---
 TestAccDataSourceTag
 TestAccDataSourceTopicMetrics
+TestAccDataSourceTopics
 
 # --- Pipelines ---
 TestAccPostgreSQLSnowflakePipelineResource


### PR DESCRIPTION
Add TestAccSourceWebhookResource, TestAccSourceShopifyWebhookResource, TestAccSourceStripeWebhookResource, and TestAccDataSourceTopics to the curated list. Webhook and Topics run unconditionally; Shopify/Stripe self-skip until their TF_VAR_* keys are present in the 1Password env.json blob.