### PR TITLE
[v2] docs(changelog): mark v2.1.22 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
-## 0.1.0 (Unreleased)
+# Changelog
 
-FEATURES:
+## Unreleased
 
-BUG FIXES:
+## 2.1.22 (June 22, 2026)
+
+### Fixed
 
 * **Provider error handling**: API errors that return a non-JSON body (gateway HTML pages, WAF blocks, proxy 5xx) now surface as `unexpected <status> <status text> from <method> <url>: <body snippet>` instead of the cryptic `invalid character '<' looking for beginning of value`. The HTTP status, URL, and a truncated body snippet are included directly in the Terraform error, so failures like 504 gateway timeouts on long-running operations are diagnosable without re-running with `TF_LOG=DEBUG`. Resolves ENG-2460.
 


### PR DESCRIPTION
**Target:** v2 (main)

Promotes the `Unreleased` changelog section to a `2.1.22 (June 22, 2026)` release entry, matching the `v2.1.22` tag that was just pushed.

Also restructures the changelog to Keep-a-Changelog–style headings (Fixed/Added/Changed/etc.) and adds a top-level `# Changelog` heading (clears a markdownlint warning).

No code changes — docs only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error messages for non-JSON API responses with detailed diagnostic information including HTTP status codes, request method and URL, and response body snippets to aid in troubleshooting.
  * Improved Terraform resource handling to automatically remove deleted resources from state during read operations instead of reporting errors when resources no longer exist.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->