### PR TITLE
feat(bigquery)!: target the Aiven BigQuery sink (Storage Write API)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     `custom_bigquery_partition_field`, `custom_bigquery_cluster_field`,
     `bigquery_time_based_partition`.
   - **Added:** `keyfile` (required, sensitive — service-account JSON),
-    `default_dataset` (required), `time_partitioning_type` (default `DAY`),
-    `custom_partition_field`, `custom_clustering_fields`, `auto_create_tables`
+    `default_dataset` (required), `time_partitioning_type` (default `DAY`,
+    accepts `NONE` for non-partitioned tables), `custom_partition_field`,
+    `custom_clustering_fields`, `custom_partition_expiration_days` (optional —
+    auto-drop partitions older than N days), `auto_create_tables`
     (default `true`), `allow_new_big_query_fields` (default `true`),
     `allow_big_query_required_field_relaxation` (default `true`).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **`streamkap_destination_bigquery`** now provisions the Aiven BigQuery sink
+  (Storage Write API, append-only) — the only supported BigQuery destination.
+  The schema is replaced to match:
+  - **Removed:** `bigquery_json`, `table_name_prefix`, `bigquery_region`,
+    `custom_bigquery_partition_field`, `custom_bigquery_cluster_field`,
+    `bigquery_time_based_partition`.
+  - **Added:** `keyfile` (required, sensitive — service-account JSON),
+    `default_dataset` (required), `time_partitioning_type` (default `DAY`),
+    `custom_partition_field`, `custom_clustering_fields`, `auto_create_tables`
+    (default `true`), `allow_new_big_query_fields` (default `true`),
+    `allow_big_query_required_field_relaxation` (default `true`).
+
+  This is a breaking change for the beta line; update existing
+  `streamkap_destination_bigquery` configurations to the new attributes.
+
 ## [3.0.0-beta.22] - 2026-06-22 (Pre-release)
 
 ### Added

--- a/docs/resources/destination_bigquery.md
+++ b/docs/resources/destination_bigquery.md
@@ -23,24 +23,26 @@ This resource creates and manages a BigQuery destination for Streamkap data pipe
 
 ### Required
 
-- `bigquery_json` (String, Sensitive) Upload the Bigquery JSON file.
+- `default_dataset` (String) Name of the destination BigQuery dataset. The dataset must already exist.
+- `keyfile` (String, Sensitive) Upload the BigQuery service-account JSON key file.
 
 **Security:** This value is marked sensitive and will not appear in CLI output or logs.
 - `name` (String) Name of the destination
-- `table_name_prefix` (String) Name of the destination Dataset for the of the associated table name
 
 ### Optional
 
-- `bigquery_region` (String) Region of the bigquery Dataset. Defaults to `us-central1`. Valid values: `us-east5`, `us-central1`, `us-west4`, `us-west2`, `northamerica-northeast1`, `us-east4`, `us-west1`, `us-west3`, `southamerica-east1`, `southamerica-west1`, `us-east1`, `northamerica-northeast2`, `asia-south2`, `asia-east2`, `asia-southeast2`, `australia-southeast2`, `asia-south1`, `asia-northeast2`, `asia-northeast3`, `asia-southeast1`, `australia-southeast1`, `asia-east1`, `asia-northeast1`, `europe-west1`, `europe-north1`, `europe-west3`, `europe-west2`, `europe-southwest1`, `europe-west8`, `europe-west4`, `europe-west9`, `europe-central2`, `europe-west6`, `EU`, `US`.
-- `bigquery_time_based_partition` (Boolean) Is the partition time based?. Defaults to `false`.
+- `allow_big_query_required_field_relaxation` (Boolean) Allow changing BigQuery columns from REQUIRED to NULLABLE when the schema evolves. Defaults to `true`.
+- `allow_new_big_query_fields` (Boolean) Allow adding new columns to BigQuery tables when the schema evolves. Defaults to `true`.
+- `auto_create_tables` (Boolean) Automatically create BigQuery tables for new topics. Defaults to `true`.
 - `consumer_override_max_poll_records` (Number) The maximum number of records returned in a single call to poll(). Defaults to `10000`.
-- `custom_bigquery_cluster_field` (String) User can set a Bigquery cluster field.
-- `custom_bigquery_partition_field` (String) User can set custom name of the partition field
+- `custom_clustering_fields` (String) Optional comma-separated list of fields to cluster the table by (max 4).
+- `custom_partition_field` (String) Optional record field to partition by. Leave blank for ingestion-time partitioning.
 - `kc_cluster_id` (String) Kafka Connect cluster ID to deploy the connector to. Empty for default cluster.
 - `preserve_null_values` (Boolean) When enabled, preserves NULL values from the source database instead of replacing them with schema default values. Enable this if you need to distinguish between explicit NULLs and default values. Defaults to `false`.
 - `quote_identifiers` (Boolean) Whether to quote identifiers in SQL statements. Defaults to `true`.
 - `tags` (Set of String) Optional set of tag IDs to apply to this destination. Use `streamkap_tag` (resource or data source) to obtain IDs. Defaults to empty; the backend may attach tags out-of-band, in which case the unset value is preserved on subsequent reads.
 - `tasks_max` (Number) The maximum number of active tasks. Defaults to `5`.
+- `time_partitioning_type` (String) Time partitioning granularity used when auto-creating tables. Defaults to `DAY`. Valid values: `DAY`, `HOUR`, `MONTH`, `YEAR`.
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 - `transforms_add_string_suffix_fields_include_list` (String) Warning: Should only be used in conjunction with numeric conversion or other conversions. If field remained string after previous conversion, rename to field to <previous-field-name>_str. Comma separated list of table columns in format 'table1.column1,table2.column2'
 - `transforms_change_topic_name_match_regex` (String) Regular expression for matching topic name parts to use as the destination table (database) or file (file storage) name

--- a/docs/resources/destination_bigquery.md
+++ b/docs/resources/destination_bigquery.md
@@ -36,13 +36,14 @@ This resource creates and manages a BigQuery destination for Streamkap data pipe
 - `auto_create_tables` (Boolean) Automatically create BigQuery tables for new topics. Defaults to `true`.
 - `consumer_override_max_poll_records` (Number) The maximum number of records returned in a single call to poll(). Defaults to `10000`.
 - `custom_clustering_fields` (String) Optional comma-separated list of fields to cluster the table by (max 4).
+- `custom_partition_expiration_days` (String) Optional. Automatically delete partitions older than this many days from tables this destination creates. Leave blank to keep all partitions. Ignored when Time Partitioning is NONE.
 - `custom_partition_field` (String) Optional record field to partition by. Leave blank for ingestion-time partitioning.
 - `kc_cluster_id` (String) Kafka Connect cluster ID to deploy the connector to. Empty for default cluster.
 - `preserve_null_values` (Boolean) When enabled, preserves NULL values from the source database instead of replacing them with schema default values. Enable this if you need to distinguish between explicit NULLs and default values. Defaults to `false`.
 - `quote_identifiers` (Boolean) Whether to quote identifiers in SQL statements. Defaults to `true`.
 - `tags` (Set of String) Optional set of tag IDs to apply to this destination. Use `streamkap_tag` (resource or data source) to obtain IDs. Defaults to empty; the backend may attach tags out-of-band, in which case the unset value is preserved on subsequent reads.
 - `tasks_max` (Number) The maximum number of active tasks. Defaults to `5`.
-- `time_partitioning_type` (String) Time partitioning granularity used when auto-creating tables. Defaults to `DAY`. Valid values: `DAY`, `HOUR`, `MONTH`, `YEAR`.
+- `time_partitioning_type` (String) Time partitioning granularity used when auto-creating tables. Select NONE to create non-partitioned tables. Defaults to `DAY`. Valid values: `DAY`, `HOUR`, `MONTH`, `YEAR`, `NONE`.
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 - `transforms_add_string_suffix_fields_include_list` (String) Warning: Should only be used in conjunction with numeric conversion or other conversions. If field remained string after previous conversion, rename to field to <previous-field-name>_str. Comma separated list of table columns in format 'table1.column1,table2.column2'
 - `transforms_change_topic_name_match_regex` (String) Regular expression for matching topic name parts to use as the destination table (database) or file (file storage) name

--- a/examples/resources/streamkap_destination_bigquery/basic.tf
+++ b/examples/resources/streamkap_destination_bigquery/basic.tf
@@ -1,25 +1,18 @@
 # Minimal BigQuery destination configuration
 
 resource "streamkap_destination_bigquery" "example" {
-  name              = "my-bigquery-dest"
-  bigquery_json     = var.bigquery_json
-  table_name_prefix = var.dataset_name
-  bigquery_region   = var.bigquery_region
+  name            = "my-bigquery-dest"
+  keyfile         = var.bigquery_keyfile
+  default_dataset = var.bigquery_dataset
 }
 
-variable "bigquery_json" {
-  description = "GCP service account credentials JSON"
+variable "bigquery_keyfile" {
+  description = "BigQuery service-account JSON key file contents"
   type        = string
   sensitive   = true
 }
 
-variable "dataset_name" {
-  description = "BigQuery dataset name (used as table prefix)"
+variable "bigquery_dataset" {
+  description = "Destination BigQuery dataset name (must already exist)"
   type        = string
-}
-
-variable "bigquery_region" {
-  description = "BigQuery region"
-  type        = string
-  default     = "us-central1"
 }

--- a/examples/resources/streamkap_destination_bigquery/complete.tf
+++ b/examples/resources/streamkap_destination_bigquery/complete.tf
@@ -25,9 +25,10 @@ resource "streamkap_destination_bigquery" "example" {
   default_dataset = "streamkap_dataset"              # Destination dataset (must already exist)
 
   # Partitioning and clustering
-  time_partitioning_type   = "DAY"             # Partition granularity. Default: DAY. Valid: DAY, HOUR, MONTH, YEAR
-  custom_partition_field   = "partition_field" # Optional record field to partition by. Blank = ingestion-time
-  custom_clustering_fields = "field1,field2"   # Optional comma-separated fields to cluster by (max 4)
+  time_partitioning_type           = "DAY"             # Partition granularity. Default: DAY. Valid: DAY, HOUR, MONTH, YEAR, NONE
+  custom_partition_field           = "partition_field" # Optional record field to partition by. Blank = ingestion-time
+  custom_clustering_fields         = "field1,field2"   # Optional comma-separated fields to cluster by (max 4)
+  custom_partition_expiration_days = "30"              # Optional. Drop partitions older than N days. Blank = keep all. Ignored when NONE
 
   # Schema evolution
   auto_create_tables                        = true # Auto-create tables for new topics. Default: true

--- a/examples/resources/streamkap_destination_bigquery/complete.tf
+++ b/examples/resources/streamkap_destination_bigquery/complete.tf
@@ -10,33 +10,29 @@ terraform {
 
 provider "streamkap" {}
 
-variable "destination_bigquery_json" {
+variable "destination_bigquery_keyfile" {
   type        = string
   sensitive   = true
-  description = "The BigQuery service account JSON credentials"
+  description = "BigQuery service-account JSON key file contents"
 }
 
 # Complete BigQuery destination configuration with all options
 resource "streamkap_destination_bigquery" "example" {
   name = "example-destination-bigquery"
 
-  # Connection settings (required)
-  bigquery_json     = var.destination_bigquery_json
-  table_name_prefix = "streamkap_dataset" # Destination Dataset name
-
-  # Region configuration
-  bigquery_region = "us-central1" # Default: us-central1
-  # Valid values: us-east5, us-central1, us-west4, us-west2, northamerica-northeast1,
-  # us-east4, us-west1, us-west3, southamerica-east1, southamerica-west1, us-east1,
-  # northamerica-northeast2, asia-south2, asia-east2, asia-southeast2, australia-southeast2,
-  # asia-south1, asia-northeast2, asia-northeast3, asia-southeast1, australia-southeast1,
-  # asia-east1, asia-northeast1, europe-west1, europe-north1, europe-west3, europe-west2,
-  # europe-southwest1, europe-west8, europe-west4, europe-west9, europe-central2, europe-west6, EU, US
+  # Connection (required)
+  keyfile         = var.destination_bigquery_keyfile # Service-account JSON key (sensitive)
+  default_dataset = "streamkap_dataset"              # Destination dataset (must already exist)
 
   # Partitioning and clustering
-  custom_bigquery_cluster_field   = "cluster_field"   # Custom cluster field name
-  custom_bigquery_partition_field = "partition_field" # Custom partition field name
-  bigquery_time_based_partition   = false             # Time-based partitioning. Default: false
+  time_partitioning_type   = "DAY"             # Partition granularity. Default: DAY. Valid: DAY, HOUR, MONTH, YEAR
+  custom_partition_field   = "partition_field" # Optional record field to partition by. Blank = ingestion-time
+  custom_clustering_fields = "field1,field2"   # Optional comma-separated fields to cluster by (max 4)
+
+  # Schema evolution
+  auto_create_tables                        = true # Auto-create tables for new topics. Default: true
+  allow_new_big_query_fields                = true # Add new columns as the schema evolves. Default: true
+  allow_big_query_required_field_relaxation = true # Relax REQUIRED -> NULLABLE as the schema evolves. Default: true
 
   # Performance settings
   tasks_max = 5 # Max active tasks (1-10). Default: 5

--- a/internal/generated/destination_bigquery.go
+++ b/internal/generated/destination_bigquery.go
@@ -31,6 +31,7 @@ type DestinationBigqueryModel struct {
 	TimePartitioningType                             types.String         `tfsdk:"time_partitioning_type"`
 	CustomPartitionField                             types.String         `tfsdk:"custom_partition_field"`
 	CustomClusteringFields                           types.String         `tfsdk:"custom_clustering_fields"`
+	CustomPartitionExpirationDays                    types.String         `tfsdk:"custom_partition_expiration_days"`
 	AutoCreateTables                                 types.Bool           `tfsdk:"auto_create_tables"`
 	AllowNewBigQueryFields                           types.Bool           `tfsdk:"allow_new_big_query_fields"`
 	AllowBigQueryRequiredFieldRelaxation             types.Bool           `tfsdk:"allow_big_query_required_field_relaxation"`
@@ -138,11 +139,11 @@ func DestinationBigquerySchema() schema.Schema {
 			"time_partitioning_type": schema.StringAttribute{
 				Optional:            true,
 				Computed:            true,
-				Description:         "Time partitioning granularity used when auto-creating tables. Defaults to \"DAY\". Valid values: DAY, HOUR, MONTH, YEAR.",
-				MarkdownDescription: "Time partitioning granularity used when auto-creating tables. Defaults to `DAY`. Valid values: `DAY`, `HOUR`, `MONTH`, `YEAR`.",
+				Description:         "Time partitioning granularity used when auto-creating tables. Select NONE to create non-partitioned tables. Defaults to \"DAY\". Valid values: DAY, HOUR, MONTH, YEAR, NONE.",
+				MarkdownDescription: "Time partitioning granularity used when auto-creating tables. Select NONE to create non-partitioned tables. Defaults to `DAY`. Valid values: `DAY`, `HOUR`, `MONTH`, `YEAR`, `NONE`.",
 				Default:             stringdefault.StaticString("DAY"),
 				Validators: []validator.String{
-					stringvalidator.OneOf("DAY", "HOUR", "MONTH", "YEAR"),
+					stringvalidator.OneOf("DAY", "HOUR", "MONTH", "YEAR", "NONE"),
 				},
 			},
 			"custom_partition_field": schema.StringAttribute{
@@ -159,6 +160,15 @@ func DestinationBigquerySchema() schema.Schema {
 				Computed:            true,
 				Description:         "Optional comma-separated list of fields to cluster the table by (max 4).",
 				MarkdownDescription: "Optional comma-separated list of fields to cluster the table by (max 4).",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"custom_partition_expiration_days": schema.StringAttribute{
+				Optional:            true,
+				Computed:            true,
+				Description:         "Optional. Automatically delete partitions older than this many days from tables this destination creates. Leave blank to keep all partitions. Ignored when Time Partitioning is NONE.",
+				MarkdownDescription: "Optional. Automatically delete partitions older than this many days from tables this destination creates. Leave blank to keep all partitions. Ignored when Time Partitioning is NONE.",
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 				},
@@ -487,6 +497,7 @@ var DestinationBigqueryFieldMappings = map[string]string{
 	"time_partitioning_type":                                  "timePartitioningType",
 	"custom_partition_field":                                  "custom.partition.field",
 	"custom_clustering_fields":                                "custom.clustering.fields",
+	"custom_partition_expiration_days":                        "custom.partition.expiration.days",
 	"auto_create_tables":                                      "autoCreateTables",
 	"allow_new_big_query_fields":                              "allowNewBigQueryFields",
 	"allow_big_query_required_field_relaxation":               "allowBigQueryRequiredFieldRelaxation",

--- a/internal/generated/destination_bigquery.go
+++ b/internal/generated/destination_bigquery.go
@@ -26,12 +26,14 @@ type DestinationBigqueryModel struct {
 	ConnectorStatus                                  types.String         `tfsdk:"connector_status"`
 	KcClusterId                                      types.String         `tfsdk:"kc_cluster_id"`
 	Tags                                             types.Set            `tfsdk:"tags"`
-	BigqueryJson                                     jsontypes.Normalized `tfsdk:"bigquery_json"`
-	TableNamePrefix                                  types.String         `tfsdk:"table_name_prefix"`
-	BigqueryRegion                                   types.String         `tfsdk:"bigquery_region"`
-	CustomBigqueryClusterField                       types.String         `tfsdk:"custom_bigquery_cluster_field"`
-	CustomBigqueryPartitionField                     types.String         `tfsdk:"custom_bigquery_partition_field"`
-	BigqueryTimeBasedPartition                       types.Bool           `tfsdk:"bigquery_time_based_partition"`
+	Keyfile                                          jsontypes.Normalized `tfsdk:"keyfile"`
+	DefaultDataset                                   types.String         `tfsdk:"default_dataset"`
+	TimePartitioningType                             types.String         `tfsdk:"time_partitioning_type"`
+	CustomPartitionField                             types.String         `tfsdk:"custom_partition_field"`
+	CustomClusteringFields                           types.String         `tfsdk:"custom_clustering_fields"`
+	AutoCreateTables                                 types.Bool           `tfsdk:"auto_create_tables"`
+	AllowNewBigQueryFields                           types.Bool           `tfsdk:"allow_new_big_query_fields"`
+	AllowBigQueryRequiredFieldRelaxation             types.Bool           `tfsdk:"allow_big_query_required_field_relaxation"`
 	TasksMax                                         types.Int64          `tfsdk:"tasks_max"`
 	ConsumerOverrideMaxPollRecords                   types.Int64          `tfsdk:"consumer_override_max_poll_records"`
 	PreserveNullValues                               types.Bool           `tfsdk:"preserve_null_values"`
@@ -121,52 +123,66 @@ func DestinationBigquerySchema() schema.Schema {
 					setplanmodifier.UseStateForUnknown(),
 				},
 			},
-			"bigquery_json": schema.StringAttribute{
+			"keyfile": schema.StringAttribute{
 				Required:            true,
 				CustomType:          jsontypes.NormalizedType{},
 				Sensitive:           true,
-				Description:         "Upload the Bigquery JSON file. This value is sensitive and will not appear in logs or CLI output.",
-				MarkdownDescription: "Upload the Bigquery JSON file.\n\n**Security:** This value is marked sensitive and will not appear in CLI output or logs.",
+				Description:         "Upload the BigQuery service-account JSON key file. This value is sensitive and will not appear in logs or CLI output.",
+				MarkdownDescription: "Upload the BigQuery service-account JSON key file.\n\n**Security:** This value is marked sensitive and will not appear in CLI output or logs.",
 			},
-			"table_name_prefix": schema.StringAttribute{
+			"default_dataset": schema.StringAttribute{
 				Required:            true,
-				Description:         "Name of the destination Dataset for the of the associated table name",
-				MarkdownDescription: "Name of the destination Dataset for the of the associated table name",
+				Description:         "Name of the destination BigQuery dataset. The dataset must already exist.",
+				MarkdownDescription: "Name of the destination BigQuery dataset. The dataset must already exist.",
 			},
-			"bigquery_region": schema.StringAttribute{
+			"time_partitioning_type": schema.StringAttribute{
 				Optional:            true,
 				Computed:            true,
-				Description:         "Region of the bigquery Dataset. Defaults to \"us-central1\". Valid values: us-east5, us-central1, us-west4, us-west2, northamerica-northeast1, us-east4, us-west1, us-west3, southamerica-east1, southamerica-west1, us-east1, northamerica-northeast2, asia-south2, asia-east2, asia-southeast2, australia-southeast2, asia-south1, asia-northeast2, asia-northeast3, asia-southeast1, australia-southeast1, asia-east1, asia-northeast1, europe-west1, europe-north1, europe-west3, europe-west2, europe-southwest1, europe-west8, europe-west4, europe-west9, europe-central2, europe-west6, EU, US.",
-				MarkdownDescription: "Region of the bigquery Dataset. Defaults to `us-central1`. Valid values: `us-east5`, `us-central1`, `us-west4`, `us-west2`, `northamerica-northeast1`, `us-east4`, `us-west1`, `us-west3`, `southamerica-east1`, `southamerica-west1`, `us-east1`, `northamerica-northeast2`, `asia-south2`, `asia-east2`, `asia-southeast2`, `australia-southeast2`, `asia-south1`, `asia-northeast2`, `asia-northeast3`, `asia-southeast1`, `australia-southeast1`, `asia-east1`, `asia-northeast1`, `europe-west1`, `europe-north1`, `europe-west3`, `europe-west2`, `europe-southwest1`, `europe-west8`, `europe-west4`, `europe-west9`, `europe-central2`, `europe-west6`, `EU`, `US`.",
-				Default:             stringdefault.StaticString("us-central1"),
+				Description:         "Time partitioning granularity used when auto-creating tables. Defaults to \"DAY\". Valid values: DAY, HOUR, MONTH, YEAR.",
+				MarkdownDescription: "Time partitioning granularity used when auto-creating tables. Defaults to `DAY`. Valid values: `DAY`, `HOUR`, `MONTH`, `YEAR`.",
+				Default:             stringdefault.StaticString("DAY"),
 				Validators: []validator.String{
-					stringvalidator.OneOf("us-east5", "us-central1", "us-west4", "us-west2", "northamerica-northeast1", "us-east4", "us-west1", "us-west3", "southamerica-east1", "southamerica-west1", "us-east1", "northamerica-northeast2", "asia-south2", "asia-east2", "asia-southeast2", "australia-southeast2", "asia-south1", "asia-northeast2", "asia-northeast3", "asia-southeast1", "australia-southeast1", "asia-east1", "asia-northeast1", "europe-west1", "europe-north1", "europe-west3", "europe-west2", "europe-southwest1", "europe-west8", "europe-west4", "europe-west9", "europe-central2", "europe-west6", "EU", "US"),
+					stringvalidator.OneOf("DAY", "HOUR", "MONTH", "YEAR"),
 				},
 			},
-			"custom_bigquery_cluster_field": schema.StringAttribute{
+			"custom_partition_field": schema.StringAttribute{
 				Optional:            true,
 				Computed:            true,
-				Description:         "User can set a Bigquery cluster field.",
-				MarkdownDescription: "User can set a Bigquery cluster field.",
+				Description:         "Optional record field to partition by. Leave blank for ingestion-time partitioning.",
+				MarkdownDescription: "Optional record field to partition by. Leave blank for ingestion-time partitioning.",
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 				},
 			},
-			"custom_bigquery_partition_field": schema.StringAttribute{
+			"custom_clustering_fields": schema.StringAttribute{
 				Optional:            true,
 				Computed:            true,
-				Description:         "User can set custom name of the partition field",
-				MarkdownDescription: "User can set custom name of the partition field",
+				Description:         "Optional comma-separated list of fields to cluster the table by (max 4).",
+				MarkdownDescription: "Optional comma-separated list of fields to cluster the table by (max 4).",
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 				},
 			},
-			"bigquery_time_based_partition": schema.BoolAttribute{
+			"auto_create_tables": schema.BoolAttribute{
 				Optional:            true,
 				Computed:            true,
-				Description:         "Is the partition time based?. Defaults to false.",
-				MarkdownDescription: "Is the partition time based?. Defaults to `false`.",
-				Default:             booldefault.StaticBool(false),
+				Description:         "Automatically create BigQuery tables for new topics. Defaults to true.",
+				MarkdownDescription: "Automatically create BigQuery tables for new topics. Defaults to `true`.",
+				Default:             booldefault.StaticBool(true),
+			},
+			"allow_new_big_query_fields": schema.BoolAttribute{
+				Optional:            true,
+				Computed:            true,
+				Description:         "Allow adding new columns to BigQuery tables when the schema evolves. Defaults to true.",
+				MarkdownDescription: "Allow adding new columns to BigQuery tables when the schema evolves. Defaults to `true`.",
+				Default:             booldefault.StaticBool(true),
+			},
+			"allow_big_query_required_field_relaxation": schema.BoolAttribute{
+				Optional:            true,
+				Computed:            true,
+				Description:         "Allow changing BigQuery columns from REQUIRED to NULLABLE when the schema evolves. Defaults to true.",
+				MarkdownDescription: "Allow changing BigQuery columns from REQUIRED to NULLABLE when the schema evolves. Defaults to `true`.",
+				Default:             booldefault.StaticBool(true),
 			},
 			"tasks_max": schema.Int64Attribute{
 				Optional:            true,
@@ -466,12 +482,14 @@ func DestinationBigquerySchema() schema.Schema {
 
 // DestinationBigqueryFieldMappings maps Terraform attribute names to API field names.
 var DestinationBigqueryFieldMappings = map[string]string{
-	"bigquery_json":                                           "bigquery.json",
-	"table_name_prefix":                                       "table.name.prefix",
-	"bigquery_region":                                         "bigquery.region",
-	"custom_bigquery_cluster_field":                           "custom.bigquery.cluster.field",
-	"custom_bigquery_partition_field":                         "custom.bigquery.partition.field",
-	"bigquery_time_based_partition":                           "bigquery.time.based.partition",
+	"keyfile":                                                 "keyfile",
+	"default_dataset":                                         "defaultDataset",
+	"time_partitioning_type":                                  "timePartitioningType",
+	"custom_partition_field":                                  "custom.partition.field",
+	"custom_clustering_fields":                                "custom.clustering.fields",
+	"auto_create_tables":                                      "autoCreateTables",
+	"allow_new_big_query_fields":                              "allowNewBigQueryFields",
+	"allow_big_query_required_field_relaxation":               "allowBigQueryRequiredFieldRelaxation",
 	"tasks_max":                                               "tasks.max",
 	"consumer_override_max_poll_records":                      "consumer.override.max.poll.records",
 	"preserve_null_values":                                    "preserve.null.values",

--- a/internal/provider/destination_bigquery_resource_test.go
+++ b/internal/provider/destination_bigquery_resource_test.go
@@ -90,3 +90,79 @@ resource "streamkap_destination_bigquery" "test" {
 		},
 	})
 }
+
+// TestAccDestinationBigqueryResource_PartitionAndClustering exercises the custom
+// partition key and (single and multi-field) clustering keys. Field names mirror the
+// sample sales schema (products: created_at / category_id, price; orders: order_date /
+// customer_id, status, order_number) so the config reads like a real pipeline target.
+// Clustering accepts a comma-separated list of up to 4 fields.
+func TestAccDestinationBigqueryResource_PartitionAndClustering(t *testing.T) {
+	var destinationBigqueryJson = os.Getenv("TF_VAR_destination_bigquery_json")
+	var destinationBigqueryDataset = os.Getenv("TF_VAR_destination_bigquery_dataset")
+	if destinationBigqueryJson == "" || destinationBigqueryDataset == "" {
+		t.Skip("Skipping TestAccDestinationBigqueryResource_PartitionAndClustering: TF_VAR_destination_bigquery_json or TF_VAR_destination_bigquery_dataset not set")
+	}
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckDestinationDestroy,
+		Steps: []resource.TestStep{
+			// Single partition field + single clustering field (sales.products shape)
+			{
+				Config: providerConfig + `
+variable "destination_bigquery_json" {
+	type        = string
+	sensitive   = true
+	description = "BigQuery service-account JSON key file contents"
+}
+variable "destination_bigquery_dataset" {
+	type        = string
+	description = "BigQuery destination dataset name"
+}
+resource "streamkap_destination_bigquery" "test" {
+	name                     = "tf-acc-test-bigquery-partclust"
+	keyfile                  = var.destination_bigquery_json
+	default_dataset          = var.destination_bigquery_dataset
+	time_partitioning_type   = "DAY"
+	custom_partition_field   = "created_at"
+	custom_clustering_fields = "category_id"
+}
+`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("streamkap_destination_bigquery.test", "time_partitioning_type", "DAY"),
+					resource.TestCheckResourceAttr("streamkap_destination_bigquery.test", "custom_partition_field", "created_at"),
+					resource.TestCheckResourceAttr("streamkap_destination_bigquery.test", "custom_clustering_fields", "category_id"),
+					resource.TestCheckResourceAttrSet("streamkap_destination_bigquery.test", "id"),
+				),
+			},
+			// Update: different partition field + multi-field clustering, max 4 (sales.orders shape)
+			{
+				Config: providerConfig + `
+variable "destination_bigquery_json" {
+	type        = string
+	sensitive   = true
+	description = "BigQuery service-account JSON key file contents"
+}
+variable "destination_bigquery_dataset" {
+	type        = string
+	description = "BigQuery destination dataset name"
+}
+resource "streamkap_destination_bigquery" "test" {
+	name                     = "tf-acc-test-bigquery-partclust"
+	keyfile                  = var.destination_bigquery_json
+	default_dataset          = var.destination_bigquery_dataset
+	time_partitioning_type   = "HOUR"
+	custom_partition_field   = "order_date"
+	custom_clustering_fields = "customer_id,status,order_number"
+}
+`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("streamkap_destination_bigquery.test", "time_partitioning_type", "HOUR"),
+					resource.TestCheckResourceAttr("streamkap_destination_bigquery.test", "custom_partition_field", "order_date"),
+					resource.TestCheckResourceAttr("streamkap_destination_bigquery.test", "custom_clustering_fields", "customer_id,status,order_number"),
+				),
+			},
+			// Delete testing automatically occurs in TestCase
+		},
+	})
+}

--- a/internal/provider/destination_bigquery_resource_test.go
+++ b/internal/provider/destination_bigquery_resource_test.go
@@ -24,27 +24,26 @@ func TestAccDestinationBigqueryResource(t *testing.T) {
 variable "destination_bigquery_json" {
 	type        = string
 	sensitive   = true
-	description = "BigQuery JSON credentials file content"
+	description = "BigQuery service-account JSON key file contents"
 }
 variable "destination_bigquery_dataset" {
 	type        = string
-	description = "BigQuery dataset name (table_name_prefix)"
+	description = "BigQuery destination dataset name"
 }
 resource "streamkap_destination_bigquery" "test" {
-	name                            = "tf-acc-test-destination-bigquery"
-	bigquery_json                   = var.destination_bigquery_json
-	table_name_prefix               = var.destination_bigquery_dataset
-	bigquery_region                 = "us-central1"
-	bigquery_time_based_partition   = false
-	tasks_max                       = 5
+	name                   = "tf-acc-test-destination-bigquery"
+	keyfile                = var.destination_bigquery_json
+	default_dataset        = var.destination_bigquery_dataset
+	time_partitioning_type = "DAY"
+	auto_create_tables     = true
+	tasks_max              = 5
 }
 `,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("streamkap_destination_bigquery.test", "name", "tf-acc-test-destination-bigquery"),
-					resource.TestCheckResourceAttr("streamkap_destination_bigquery.test", "bigquery_json", destinationBigqueryJson),
-					resource.TestCheckResourceAttr("streamkap_destination_bigquery.test", "table_name_prefix", destinationBigqueryDataset),
-					resource.TestCheckResourceAttr("streamkap_destination_bigquery.test", "bigquery_region", "us-central1"),
-					resource.TestCheckResourceAttr("streamkap_destination_bigquery.test", "bigquery_time_based_partition", "false"),
+					resource.TestCheckResourceAttr("streamkap_destination_bigquery.test", "default_dataset", destinationBigqueryDataset),
+					resource.TestCheckResourceAttr("streamkap_destination_bigquery.test", "time_partitioning_type", "DAY"),
+					resource.TestCheckResourceAttr("streamkap_destination_bigquery.test", "auto_create_tables", "true"),
 					resource.TestCheckResourceAttr("streamkap_destination_bigquery.test", "tasks_max", "5"),
 					resource.TestCheckResourceAttrSet("streamkap_destination_bigquery.test", "id"),
 					resource.TestCheckResourceAttr("streamkap_destination_bigquery.test", "connector", "bigquery"),
@@ -55,7 +54,7 @@ resource "streamkap_destination_bigquery" "test" {
 				ResourceName:            "streamkap_destination_bigquery.test",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"connector_status"},
+				ImportStateVerifyIgnore: []string{"connector_status", "keyfile"},
 			},
 			// Update and Read testing
 			{
@@ -63,28 +62,28 @@ resource "streamkap_destination_bigquery" "test" {
 variable "destination_bigquery_json" {
 	type        = string
 	sensitive   = true
-	description = "BigQuery JSON credentials file content"
+	description = "BigQuery service-account JSON key file contents"
 }
 variable "destination_bigquery_dataset" {
 	type        = string
-	description = "BigQuery dataset name (table_name_prefix)"
+	description = "BigQuery destination dataset name"
 }
 resource "streamkap_destination_bigquery" "test" {
-	name                            = "tf-acc-test-destination-bigquery-updated"
-	bigquery_json                   = var.destination_bigquery_json
-	table_name_prefix               = var.destination_bigquery_dataset
-	bigquery_region                 = "us-east1"
-	bigquery_time_based_partition   = true
-	tasks_max                       = 3
-	custom_bigquery_partition_field = "_streamkap_ts"
+	name                     = "tf-acc-test-destination-bigquery-updated"
+	keyfile                  = var.destination_bigquery_json
+	default_dataset          = var.destination_bigquery_dataset
+	time_partitioning_type   = "HOUR"
+	tasks_max                = 3
+	custom_partition_field   = "_streamkap_ts"
+	custom_clustering_fields = "id"
 }
 `,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("streamkap_destination_bigquery.test", "name", "tf-acc-test-destination-bigquery-updated"),
-					resource.TestCheckResourceAttr("streamkap_destination_bigquery.test", "bigquery_region", "us-east1"),
-					resource.TestCheckResourceAttr("streamkap_destination_bigquery.test", "bigquery_time_based_partition", "true"),
+					resource.TestCheckResourceAttr("streamkap_destination_bigquery.test", "time_partitioning_type", "HOUR"),
 					resource.TestCheckResourceAttr("streamkap_destination_bigquery.test", "tasks_max", "3"),
-					resource.TestCheckResourceAttr("streamkap_destination_bigquery.test", "custom_bigquery_partition_field", "_streamkap_ts"),
+					resource.TestCheckResourceAttr("streamkap_destination_bigquery.test", "custom_partition_field", "_streamkap_ts"),
+					resource.TestCheckResourceAttr("streamkap_destination_bigquery.test", "custom_clustering_fields", "id"),
 				),
 			},
 			// Delete testing automatically occurs in TestCase

--- a/internal/provider/schema_validation_test.go
+++ b/internal/provider/schema_validation_test.go
@@ -60,8 +60,8 @@ func TestSchemaValidation_MissingRequiredField_BigQuery(t *testing.T) {
 	// Required fields
 	requiredFields := []string{
 		"name",
-		"bigquery_json",
-		"table_name_prefix",
+		"keyfile",
+		"default_dataset",
 	}
 
 	for _, field := range requiredFields {
@@ -72,11 +72,11 @@ func TestSchemaValidation_MissingRequiredField_BigQuery(t *testing.T) {
 		})
 	}
 
-	// Verify bigquery_region is optional (has default value)
-	t.Run("optional_bigquery_region", func(t *testing.T) {
-		attr, ok := schema.Attributes["bigquery_region"]
-		require.True(t, ok, "bigquery_region attribute should exist")
-		require.True(t, attr.IsOptional(), "bigquery_region should be optional (has default)")
+	// Verify time_partitioning_type is optional (has default value)
+	t.Run("optional_time_partitioning_type", func(t *testing.T) {
+		attr, ok := schema.Attributes["time_partitioning_type"]
+		require.True(t, ok, "time_partitioning_type attribute should exist")
+		require.True(t, attr.IsOptional(), "time_partitioning_type should be optional (has default)")
 	})
 }
 

--- a/internal/provider/schema_validation_test.go
+++ b/internal/provider/schema_validation_test.go
@@ -87,7 +87,7 @@ func TestSchemaValidation_MissingRequiredField_BigQuery(t *testing.T) {
 func TestSchemaValidation_BigQueryPartitionAndClustering(t *testing.T) {
 	schema := generated.DestinationBigquerySchema()
 
-	for _, field := range []string{"custom_partition_field", "custom_clustering_fields"} {
+	for _, field := range []string{"custom_partition_field", "custom_clustering_fields", "custom_partition_expiration_days"} {
 		t.Run("optional_"+field, func(t *testing.T) {
 			attr, ok := schema.Attributes[field]
 			require.True(t, ok, "%s attribute should exist", field)
@@ -100,6 +100,20 @@ func TestSchemaValidation_BigQueryPartitionAndClustering(t *testing.T) {
 		"custom_partition_field must map to the custom.partition.field API key")
 	require.Equal(t, "custom.clustering.fields", mappings["custom_clustering_fields"],
 		"custom_clustering_fields must map to the custom.clustering.fields API key")
+	require.Equal(t, "custom.partition.expiration.days", mappings["custom_partition_expiration_days"],
+		"custom_partition_expiration_days must map to the custom.partition.expiration.days API key")
+}
+
+// TestSchemaValidation_BigQueryTimePartitioningNone verifies NONE is an accepted
+// time partitioning option (non-partitioned tables) alongside the time-unit values.
+func TestSchemaValidation_BigQueryTimePartitioningNone(t *testing.T) {
+	v := stringvalidator.OneOf("DAY", "HOUR", "MONTH", "YEAR", "NONE")
+	for _, val := range []string{"DAY", "HOUR", "MONTH", "YEAR", "NONE"} {
+		req := validator.StringRequest{ConfigValue: types.StringValue(val)}
+		resp := &validator.StringResponse{}
+		v.ValidateString(context.Background(), req, resp)
+		require.False(t, resp.Diagnostics.HasError(), "%s should be a valid time_partitioning_type", val)
+	}
 }
 
 // TestSchemaValidation_MissingRequiredField_ClickHouse tests ClickHouse destination

--- a/internal/provider/schema_validation_test.go
+++ b/internal/provider/schema_validation_test.go
@@ -80,6 +80,28 @@ func TestSchemaValidation_MissingRequiredField_BigQuery(t *testing.T) {
 	})
 }
 
+// TestSchemaValidation_BigQueryPartitionAndClustering verifies the custom partition
+// and clustering key attributes exist as optional fields and map to the correct
+// Kafka Connect config keys (the backend then resolves these to
+// timestampPartitionFieldName / clusteringPartitionFieldNames).
+func TestSchemaValidation_BigQueryPartitionAndClustering(t *testing.T) {
+	schema := generated.DestinationBigquerySchema()
+
+	for _, field := range []string{"custom_partition_field", "custom_clustering_fields"} {
+		t.Run("optional_"+field, func(t *testing.T) {
+			attr, ok := schema.Attributes[field]
+			require.True(t, ok, "%s attribute should exist", field)
+			require.True(t, attr.IsOptional(), "%s should be optional", field)
+		})
+	}
+
+	mappings := generated.DestinationBigqueryFieldMappings
+	require.Equal(t, "custom.partition.field", mappings["custom_partition_field"],
+		"custom_partition_field must map to the custom.partition.field API key")
+	require.Equal(t, "custom.clustering.fields", mappings["custom_clustering_fields"],
+		"custom_clustering_fields must map to the custom.clustering.fields API key")
+}
+
 // TestSchemaValidation_MissingRequiredField_ClickHouse tests ClickHouse destination
 // required field validation.
 func TestSchemaValidation_MissingRequiredField_ClickHouse(t *testing.T) {

--- a/internal/provider/testdata/schemas/destination_bigquery_v1.json
+++ b/internal/provider/testdata/schemas/destination_bigquery_v1.json
@@ -43,6 +43,12 @@
       "computed": true,
       "sensitive": false
     },
+    "custom_partition_expiration_days": {
+      "required": false,
+      "optional": true,
+      "computed": true,
+      "sensitive": false
+    },
     "custom_partition_field": {
       "required": false,
       "optional": true,

--- a/internal/provider/testdata/schemas/destination_bigquery_v1.json
+++ b/internal/provider/testdata/schemas/destination_bigquery_v1.json
@@ -1,19 +1,19 @@
 {
   "version": "v3.0.0",
   "attributes": {
-    "bigquery_json": {
-      "required": true,
-      "optional": false,
-      "computed": false,
-      "sensitive": true
-    },
-    "bigquery_region": {
+    "allow_big_query_required_field_relaxation": {
       "required": false,
       "optional": true,
       "computed": true,
       "sensitive": false
     },
-    "bigquery_time_based_partition": {
+    "allow_new_big_query_fields": {
+      "required": false,
+      "optional": true,
+      "computed": true,
+      "sensitive": false
+    },
+    "auto_create_tables": {
       "required": false,
       "optional": true,
       "computed": true,
@@ -37,16 +37,22 @@
       "computed": true,
       "sensitive": false
     },
-    "custom_bigquery_cluster_field": {
+    "custom_clustering_fields": {
       "required": false,
       "optional": true,
       "computed": true,
       "sensitive": false
     },
-    "custom_bigquery_partition_field": {
+    "custom_partition_field": {
       "required": false,
       "optional": true,
       "computed": true,
+      "sensitive": false
+    },
+    "default_dataset": {
+      "required": true,
+      "optional": false,
+      "computed": false,
       "sensitive": false
     },
     "id": {
@@ -60,6 +66,12 @@
       "optional": true,
       "computed": true,
       "sensitive": false
+    },
+    "keyfile": {
+      "required": true,
+      "optional": false,
+      "computed": false,
+      "sensitive": true
     },
     "name": {
       "required": true,
@@ -79,13 +91,19 @@
       "computed": true,
       "sensitive": false
     },
-    "table_name_prefix": {
-      "required": true,
-      "optional": false,
-      "computed": false,
+    "tags": {
+      "required": false,
+      "optional": true,
+      "computed": true,
       "sensitive": false
     },
     "tasks_max": {
+      "required": false,
+      "optional": true,
+      "computed": true,
+      "sensitive": false
+    },
+    "time_partitioning_type": {
       "required": false,
       "optional": true,
       "computed": true,


### PR DESCRIPTION
## What

Regenerates the `streamkap_destination_bigquery` resource against the backend's updated BigQuery plugin mapping. BigQuery now serves the **Aiven sink** (`com.wepay.kafka.connect.bigquery`, Storage Write API) under the single `bigquery` key, replacing the non-functioning in-house sink. v3-only (BigQuery does not exist on the v2 line).

## Schema change (breaking, beta line)

| | Attributes |
|---|---|
| **Removed** | `bigquery_json`, `table_name_prefix`, `bigquery_region`, `custom_bigquery_partition_field`, `custom_bigquery_cluster_field`, `bigquery_time_based_partition` |
| **Added** | `keyfile` (required, sensitive), `default_dataset` (required), `time_partitioning_type` (default `DAY`), `custom_partition_field`, `custom_clustering_fields`, `auto_create_tables` (default `true`), `allow_new_big_query_fields` (default `true`), `allow_big_query_required_field_relaxation` (default `true`) |

## Changes
- Regenerated `internal/generated/destination_bigquery.go` (tfgen, per-connector).
- Regenerated `docs/resources/destination_bigquery.md` (tfplugindocs only — no cross-connector regen).
- Rewrote `basic.tf` / `complete.tf` examples for the new fields.
- Updated the schema snapshot, `schema_validation_test.go`, and the acceptance test.
- CHANGELOG entry under Unreleased.
- The hand-maintained wrapper (`internal/resource/destination/bigquery_generated.go`) needs no edit — it references the generated schema by name; `connector_code` stays `bigquery`.

## Notes for the reviewer
- **Generated against backend `develop`, not `main`.** The Aiven mapping isn't in backend production yet (the backend release to `main` is pending). The `bigquery` mapping on `develop` is identical to what's queued for `main`, so the output is the final production schema. **Merge this only after the backend Aiven mapping reaches production**, otherwise the provider exposes a schema the API doesn't yet serve.
- Snapshot update was scoped to bigquery only. `UPDATE_SNAPSHOTS` also surfaced pre-existing additive drift (a `tags` attribute) across ~49 other destination snapshots on `develop` — I reverted those to keep this PR focused; that drift is worth a separate cleanup.
- No migration test added: BigQuery is v3-only, so there's no v2→v3 alias to cover.

Verified: `go build ./...`, `go vet`, and `go test -short ./...` all pass.