### PR TITLE
fix(connector): preserve planned secrets to stop "inconsistent values for sensitive attribute"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **"Provider produced inconsistent result after apply: inconsistent values for
+  sensitive attribute"** on connector Create/Update. The Streamkap backend does
+  not faithfully echo every secret back even with `secret_returned=true` — it
+  returns `null` for a secret whose stored value is absent or decrypts to
+  `"null"` (e.g. Snowflake `snowflake_private_key_passphrase` when the key is not
+  passphrase-secured). The provider used the API echo as the new state, so when
+  the planned value was known but the echo differed, Terraform aborted the apply.
+  Create/Update now restore the user-supplied value for every `Sensitive` string
+  attribute after applying the API response. Applies to all source and
+  destination connectors.
+
 ## [3.0.0-beta.22] - 2026-06-22 (Pre-release)
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,6 +133,7 @@ The API client exposes `CreateTransform / GetTransform / UpdateTransform / Delet
 - Kafka Users (`/kafka-access/kafka-users`): username is the resource ID; password is write-only; no individual GET — Read filters from list.
 - Client Credentials (`/auth/client-credentials`): no Update endpoint, all fields are ForceNew; secret is only returned at creation.
 - `"produced an unexpected new value: was cty.StringVal(\"\"), but now null"` is an `Optional+Computed` echo mismatch — the API echo differs from the default. It is not just `insert_static_*`/static-transform fields: it also hits deprecated aliases and placeholder `<...>` defaults (see `HasPlaceholderDefault`). When you touch one, audit **all** siblings of that class across **every** connector — past fixes only patched a subset.
+- Secrets aren't faithfully echoed even with `secret_returned=true`: the backend returns `null` for an `encrypt: true` field whose stored value is absent or decrypts to `"null"` (`app/utils/entity_searches.py`), e.g. Snowflake `snowflake_private_key_passphrase` on a non-passphrase-secured key. The sensitive variant of the echo mismatch is `inconsistent values for sensitive attribute`. `BaseConnectorResource` Create/Update restore the planned value for every `Sensitive` string attribute after `configMapToModel` (`shared.CaptureStringFields`/`PreserveKnownStringFields`) — the configured credential is authoritative. Read keeps the API value.
 
 ## Deprecated attribute pattern (v2 → v3 aliases)
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -394,10 +394,12 @@ type ConnectorConfig interface {
 ```
 Create:
 1. Read TF config into model struct
-2. Extract name from model
-3. Convert model to API config (ModelToAPIConfig)
-4. Call API CreateSource/CreateDestination
-5. Store ID in state
+2. Capture planned Sensitive string values
+3. Extract name from model
+4. Convert model to API config (ModelToAPIConfig)
+5. Call API CreateSource/CreateDestination
+6. Convert API response to model, then restore captured secrets
+7. Store ID in state
 
 Read:
 1. Call API GetSource/GetDestination
@@ -406,9 +408,11 @@ Read:
 
 Update:
 1. Read TF config into model
-2. Convert to API config
-3. Call API UpdateSource/UpdateDestination
-4. Update state
+2. Capture planned Sensitive string values
+3. Convert to API config
+4. Call API UpdateSource/UpdateDestination
+5. Convert API response to model, then restore captured secrets
+6. Update state
 
 Delete:
 1. Call API DeleteSource/DeleteDestination

--- a/internal/resource/connector/base.go
+++ b/internal/resource/connector/base.go
@@ -204,6 +204,9 @@ func (r *BaseConnectorResource) Create(ctx context.Context, req resource.CreateR
 		return
 	}
 
+	// Capture user-supplied secrets before the API echo can overwrite them.
+	plannedSecrets := shared.CaptureStringFields(model, r.sensitiveStringAttrNames())
+
 	// Get name from model
 	name := r.getStringField(model, "Name")
 	if name == "" {
@@ -290,6 +293,7 @@ func (r *BaseConnectorResource) Create(ctx context.Context, req resource.CreateR
 	r.setStringField(model, "ConnectorStatus", connectorStatus)
 	r.setStringSliceField(model, "Tags", normalizeTagsResponse(tags, responseTags))
 	r.configMapToModel(ctx, responseConfig, model)
+	shared.PreserveKnownStringFields(model, plannedSecrets)
 
 	// Save data into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, model)...)
@@ -425,6 +429,9 @@ func (r *BaseConnectorResource) Update(ctx context.Context, req resource.UpdateR
 		return
 	}
 
+	// Capture user-supplied secrets before the API echo can overwrite them.
+	plannedSecrets := shared.CaptureStringFields(model, r.sensitiveStringAttrNames())
+
 	// Get ID and name from model
 	id := r.getStringField(model, "ID")
 	if id == "" {
@@ -507,6 +514,7 @@ func (r *BaseConnectorResource) Update(ctx context.Context, req resource.UpdateR
 	r.setStringField(model, "Connector", connectorCode)
 	r.setStringSliceField(model, "Tags", normalizeTagsResponse(tags, responseTags))
 	r.configMapToModel(ctx, responseConfig, model)
+	shared.PreserveKnownStringFields(model, plannedSecrets)
 
 	// connector_status handling on Update.
 	//
@@ -674,6 +682,22 @@ func (r *BaseConnectorResource) isJSONStringField(fieldName string, jsonStringFi
 // configMapToModel updates a model struct from a config map using the field mappings.
 func (r *BaseConnectorResource) configMapToModel(ctx context.Context, cfg map[string]any, model any) {
 	shared.ConfigMapToModel(ctx, cfg, model, r.config.GetFieldMappings(), r.setValueHook())
+}
+
+// sensitiveStringAttrNames returns the tfsdk names of every Sensitive string
+// attribute in this connector's schema. Create/Update restore the user-supplied
+// value for these after applying the API response, because the Streamkap
+// backend does not reliably echo secrets back (see
+// shared.PreserveKnownStringFields). All sensitive connector attributes are
+// strings; non-string types are intentionally ignored.
+func (r *BaseConnectorResource) sensitiveStringAttrNames() []string {
+	var names []string
+	for name, attr := range r.config.GetSchema().Attributes {
+		if sa, ok := attr.(schema.StringAttribute); ok && sa.Sensitive {
+			names = append(names, name)
+		}
+	}
+	return names
 }
 
 // extractValueHook returns a hook for shared.ExtractTerraformValue that handles

--- a/internal/resource/connector/base_test.go
+++ b/internal/resource/connector/base_test.go
@@ -1,0 +1,51 @@
+package connector
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+type fakeModel struct {
+	Name     types.String `tfsdk:"name"`
+	Password types.String `tfsdk:"password"`
+	Token    types.String `tfsdk:"token"`
+	Region   types.String `tfsdk:"region"`
+}
+
+type fakeConfig struct{}
+
+func (fakeConfig) GetSchema() schema.Schema {
+	return schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"name":     schema.StringAttribute{Required: true},
+			"password": schema.StringAttribute{Optional: true, Computed: true, Sensitive: true},
+			"token":    schema.StringAttribute{Required: true, Sensitive: true},
+			"region":   schema.StringAttribute{Optional: true},
+		},
+	}
+}
+func (fakeConfig) GetFieldMappings() map[string]string { return map[string]string{} }
+func (fakeConfig) GetConnectorType() ConnectorType     { return ConnectorTypeSource }
+func (fakeConfig) GetConnectorCode() string            { return "fake" }
+func (fakeConfig) GetResourceName() string             { return "fake" }
+func (fakeConfig) NewModelInstance() any               { return &fakeModel{} }
+
+// TestSensitiveStringAttrNames locks the contract that Create/Update use to
+// decide which fields to restore from the plan: every Sensitive string
+// attribute, regardless of Required vs Optional+Computed, and nothing else.
+func TestSensitiveStringAttrNames(t *testing.T) {
+	r := NewBaseConnectorResource(fakeConfig{}).(*BaseConnectorResource)
+
+	got := r.sensitiveStringAttrNames()
+	want := map[string]bool{"password": true, "token": true}
+	if len(got) != len(want) {
+		t.Fatalf("sensitiveStringAttrNames() = %v, want exactly %v", got, []string{"password", "token"})
+	}
+	for _, name := range got {
+		if !want[name] {
+			t.Errorf("unexpected sensitive attr %q", name)
+		}
+	}
+}

--- a/internal/resource/shared/marshaling.go
+++ b/internal/resource/shared/marshaling.go
@@ -196,6 +196,67 @@ func ConfigMapToModel(ctx context.Context, cfg map[string]any, model any, mappin
 	}
 }
 
+// CaptureStringFields snapshots the current types.String values of the named
+// tfsdk attributes from model, keyed by tfsdk name. tfsdk names that don't
+// resolve to a types.String field are skipped. Used with
+// PreserveKnownStringFields to carry user-supplied values across an API
+// round-trip that would otherwise overwrite them.
+func CaptureStringFields(model any, tfsdkNames []string) map[string]types.String {
+	if len(tfsdkNames) == 0 {
+		return nil
+	}
+
+	v, tfsdkToField := BuildTfsdkFieldIndex(model)
+
+	out := make(map[string]types.String, len(tfsdkNames))
+	for _, name := range tfsdkNames {
+		fieldPath, ok := tfsdkToField[name]
+		if !ok {
+			continue
+		}
+		if s, ok := v.FieldByIndex(fieldPath).Interface().(types.String); ok {
+			out[name] = s
+		}
+	}
+	return out
+}
+
+// PreserveKnownStringFields writes captured values back into model for every
+// field whose captured value is known (not null, not unknown), overwriting
+// whatever a prior step set.
+//
+// This implements write-only semantics for sensitive credential fields. The
+// Streamkap backend does not faithfully echo every secret back on
+// Create/Update: even with secret_returned=true it returns null for a secret
+// whose stored value is absent or decrypts to "null" (e.g. a
+// conditionally-disabled passphrase — app/utils/entity_searches.py). The
+// user-configured value is authoritative, so we restore it. Without this,
+// Terraform aborts the apply with "Provider produced inconsistent result after
+// apply: <field>: inconsistent values for sensitive attribute" whenever the
+// planned value is known but the echo differs. Captured null/unknown values are
+// left untouched so an unset Optional+Computed secret still defers to the echo.
+func PreserveKnownStringFields(model any, captured map[string]types.String) {
+	if len(captured) == 0 {
+		return
+	}
+
+	v, tfsdkToField := BuildTfsdkFieldIndex(model)
+
+	for name, val := range captured {
+		if val.IsNull() || val.IsUnknown() {
+			continue
+		}
+		fieldPath, ok := tfsdkToField[name]
+		if !ok {
+			continue
+		}
+		field := v.FieldByIndex(fieldPath)
+		if field.CanSet() && field.Type() == reflect.TypeOf(types.String{}) {
+			field.Set(reflect.ValueOf(val))
+		}
+	}
+}
+
 // GetStringField gets a string value from a model field by name using reflection.
 func GetStringField(model any, fieldName string) string {
 	v := reflect.ValueOf(model)

--- a/internal/resource/shared/marshaling_test.go
+++ b/internal/resource/shared/marshaling_test.go
@@ -364,3 +364,72 @@ func TestGetSetStringField_NonPointer(t *testing.T) {
 		t.Errorf("SetStringField(pointer) = %q, want 'modified'", model.Name.ValueString())
 	}
 }
+
+// secretModel mirrors a connector with one user-supplied secret string field.
+type secretModel struct {
+	Name   types.String `tfsdk:"name"`
+	Secret types.String `tfsdk:"secret"`
+}
+
+// TestPreserveKnownStringFields reproduces the write-only-secret round-trip:
+// the user supplies a sensitive value in the plan, the backend echo nulls it
+// (the Streamkap API returns null for a secret whose stored value is absent or
+// decrypts to "null"), and the captured plan value must be restored so the
+// applied state matches the plan. Without restoration Terraform aborts with
+// "Provider produced inconsistent result after apply: <field>: inconsistent
+// values for sensitive attribute".
+func TestPreserveKnownStringFields(t *testing.T) {
+	ctx := context.Background()
+	mappings := map[string]string{
+		"name":   "name",
+		"secret": "secret.api.field",
+	}
+
+	t.Run("restores known plan secret when echo is null", func(t *testing.T) {
+		model := &secretModel{Name: types.StringValue("dest"), Secret: types.StringValue("p@ss")}
+		captured := CaptureStringFields(model, []string{"secret"})
+
+		// Echo omits the secret -> ConfigMapToModel nulls it.
+		ConfigMapToModel(ctx, map[string]any{"name": "dest"}, model, mappings, nil)
+		if !model.Secret.IsNull() {
+			t.Fatalf("precondition: expected echo to null the secret, got %#v", model.Secret)
+		}
+
+		PreserveKnownStringFields(model, captured)
+		if model.Secret.ValueString() != "p@ss" {
+			t.Errorf("secret not restored: got %q, want %q", model.Secret.ValueString(), "p@ss")
+		}
+	})
+
+	t.Run("keeps echo value when plan secret was unknown", func(t *testing.T) {
+		model := &secretModel{Name: types.StringValue("dest"), Secret: types.StringUnknown()}
+		captured := CaptureStringFields(model, []string{"secret"})
+
+		ConfigMapToModel(ctx, map[string]any{"name": "dest", "secret.api.field": "backend-value"}, model, mappings, nil)
+		PreserveKnownStringFields(model, captured)
+		if model.Secret.ValueString() != "backend-value" {
+			t.Errorf("unknown plan should defer to echo: got %q, want %q", model.Secret.ValueString(), "backend-value")
+		}
+	})
+
+	t.Run("keeps echo value when plan secret was null", func(t *testing.T) {
+		model := &secretModel{Name: types.StringValue("dest"), Secret: types.StringNull()}
+		captured := CaptureStringFields(model, []string{"secret"})
+
+		ConfigMapToModel(ctx, map[string]any{"name": "dest", "secret.api.field": "backend-value"}, model, mappings, nil)
+		PreserveKnownStringFields(model, captured)
+		if model.Secret.ValueString() != "backend-value" {
+			t.Errorf("null plan should defer to echo: got %q, want %q", model.Secret.ValueString(), "backend-value")
+		}
+	})
+
+	t.Run("capture tolerates missing fields", func(t *testing.T) {
+		model := &secretModel{Name: types.StringValue("dest"), Secret: types.StringValue("p@ss")}
+		captured := CaptureStringFields(model, []string{"secret", "does_not_exist"})
+		if len(captured) != 1 {
+			t.Fatalf("expected 1 captured field, got %d", len(captured))
+		}
+		// Restoring into a model with no matching field must not panic.
+		PreserveKnownStringFields(&testModel{}, captured)
+	})
+}


### PR DESCRIPTION
## Problem

Reported by a user applying `streamkap_destination_snowflake`:

```
Error: Provider produced inconsistent result after apply
... produced an unexpected new value: .snowflake_private_key_passphrase:
inconsistent values for sensitive attribute.
```

## Root cause

`BaseConnectorResource` Create/Update set state from the API response config (`configMapToModel`), overwriting the user's **planned** secret values with the echo.

The Streamkap backend does **not** faithfully echo every secret back even with `secret_returned=true`. `app/utils/entity_searches.py` returns `null` for an `encrypt: true` field whose stored value is absent or decrypts to `"null"` — e.g. Snowflake `snowflake_private_key_passphrase` when the key isn't passphrase-secured (`snowflake.private.key.passphrase` is conditionally stored against `…passphrase.secured`).

When the planned value is **known** (user set it, or `UseStateForUnknown` carried prior state) but the echo is `null`/different, Terraform aborts the apply. This is the sensitive-attribute variant of the `Optional+Computed` echo mismatch the passphrase inherited when #80 made bare-Optional fields `Optional+Computed+UseStateForUnknown`.

## Fix (root level, no regen)

The schemas are correct — the bug is in the generic CRUD layer, so **no `make generate` is needed** and `internal/generated/` is untouched. Create/Update now capture the planned values of every `Sensitive` string attribute before the API call and restore the known ones after `configMapToModel`. The configured credential is authoritative; the echo for write-only secrets is not. Captured `null`/unknown values are left untouched, so an unset `Optional+Computed` secret still defers to the echo. Read is unchanged.

Applies to **all source and destination connectors**; transforms have no sensitive fields.

- `shared.CaptureStringFields` / `PreserveKnownStringFields` — reflection over the existing tfsdk field index.
- `BaseConnectorResource.sensitiveStringAttrNames` — walks the schema for `Sensitive` string attributes.

## Tests

- `TestPreserveKnownStringFields` (shared) — exercises the real `ConfigMapToModel` echo + restore: restore-on-null-echo, defer-on-unknown-plan, defer-on-null-plan, missing-field tolerance.
- `TestSensitiveStringAttrNames` (connector) — locks the detection contract (every Sensitive string, Required or Optional+Computed; nothing else).

`go build ./...`, `go vet`, and `TF_ACC= go test -short ./internal/...` all green. Full end-to-end (live API) reproduction wasn't run locally — the existing `TestAccDestinationSnowflakeResource` set-passphrase path is unaffected (restore is a no-op when the echo already matches).

## Docs

- `CHANGELOG.md` (Unreleased → Fixed), API-quirks note in `CLAUDE.md`, CRUD-flow steps in `docs/ARCHITECTURE.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)